### PR TITLE
[Bugfix]: Don't output named exports that are javascript reserved words.

### DIFF
--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -1,3 +1,4 @@
+const reserved = require("reserved-words");
 import { ClassNames, ClassName } from "lib/sass/file-to-class-names";
 
 export type ExportType = "named" | "default";
@@ -8,6 +9,19 @@ const classNameToNamedTypeDefinition = (className: ClassName) =>
 
 const classNameToInterfaceKey = (className: ClassName) =>
   `  '${className}': string;`;
+
+const isValidName = (className: ClassName) => {
+  const valid =
+    !reserved.check(className, "es5", true) &&
+    !reserved.check(className, "es6", true);
+  if (!valid) {
+    console.log(
+      `Skipping classname '${className}' as it is a reserved javascript keyword - consider either ` +
+        `renaming the scss class or using default exports instead if this classname export is required.`
+    );
+  }
+  return valid;
+};
 
 export const classNamesToTypeDefinitions = (
   classNames: ClassNames,
@@ -25,7 +39,9 @@ export const classNamesToTypeDefinitions = (
         typeDefinitions += "export default styles;\n";
         return typeDefinitions;
       case "named":
-        typeDefinitions = classNames.map(classNameToNamedTypeDefinition);
+        typeDefinitions = classNames
+          .filter(isValidName)
+          .map(classNameToNamedTypeDefinition);
 
         // Sepearte all type definitions be a newline with a trailing newline.
         return typeDefinitions.join("\n") + "\n";

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "node-sass": "^4.11.0",
     "param-case": "^2.1.1",
     "prettier": "^1.16.4",
+    "reserved-words": "^0.1.2",
     "ts-jest": "^23.10.5",
     "ts-node": "^8.0.2",
     "typescript": "^3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3473,6 +3473,11 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+reserved-words@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
+  integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
* Filter out classnames that are reserved javascript keywords in either es5 or es6 javascript.
* Output a warning for each classname filtered out, with a suggestion to use default exports instead if the filtered out classname was required as part of the export.

Use case: using bootstrap-sass (v3), the classname "in" is created. Since this is a reserved keyword in javascript, the named export definition file that was being created was invalid, breaking the ability to compile the project. However, the user is not likely to be using this as 'styles.in' anywhere, so removing the invalid export does not prevent the user from access to the classnames that they do use. The warning message both informs the user that a classname was excluded, and provides instructions on how to work around the issue if they did in fact need to access the classname as 'styles.in' in their code.