### PR TITLE
[Feature]: Implement ability to define alias prefixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ An array of paths to look in to attempt to resolve your `@import` declarations. 
 
 An object of aliases to map to their corresponding paths. This example will replace any `@import '~alias'` with `@import 'src/core/variables'`.
 
+### `--aliasPrefixes` (`-p`)
+
+- **Type**: `object`
+- **Default**: `{}`
+- **Example**: `tsm src --aliasPrefixes.~ node_modules/`
+
+An object of prefix strings to replace with their corresponding paths. This example will replace any `@import '~bootstrap/lib/bootstrap'` with `@import 'node_modules/bootstrap/lib/bootstrap'`.
+This matches the common use-case for importing scss files from node_modules when `sass-loader` will be used with `webpack` to compile the project.
+
 ### `--nameFormat` (`-n`)
 
 - **Type**: `"camel" | "kebab" | "param"`

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -30,11 +30,20 @@ const { _: patterns, ...rest } = yargs
     "$0 src/**/*.scss --aliases.~name variables",
     'Replace all imports for "~name" with "variables"'
   )
+  .example(
+    "$0 src/**/*.scss --aliasPrefixes.~ ./node_modules/",
+    'Replace the "~" prefix with "./node_modules/" for all imports beginning with "~"'
+  )
   .demandCommand(1)
   .option("aliases", {
     coerce: (obj): Aliases => obj,
     alias: "a",
     describe: "Alias any import to any other value."
+  })
+  .option("aliasPrefixes", {
+    coerce: (obj): Aliases => obj,
+    alias: "p",
+    describe: "A prefix for any import to rewrite to another value."
   })
   .option("nameFormat", {
     choices: NAME_FORMATS,

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -16,15 +16,27 @@ export type NameFormat = "camel" | "kebab" | "param";
 export interface Options {
   includePaths?: string[];
   aliases?: Aliases;
+  aliasPrefixes?: Aliases;
   nameFormat?: NameFormat;
 }
 
 export const NAME_FORMATS: NameFormat[] = ["camel", "kebab", "param"];
 
-const importer = (aliases: Aliases) => (url: string) => {
+const importer = (aliases: Aliases, aliasPrefixes: Aliases) => (
+  url: string
+) => {
   if (url in aliases) {
     return {
       file: aliases[url]
+    };
+  }
+
+  const prefixMatch = Object.keys(aliasPrefixes).find(prefix =>
+    url.startsWith(prefix)
+  );
+  if (prefixMatch) {
+    return {
+      file: aliasPrefixes[prefixMatch] + url.substr(prefixMatch.length)
     };
   }
 
@@ -36,6 +48,7 @@ export const fileToClassNames = (
   {
     includePaths = [],
     aliases = {},
+    aliasPrefixes = {},
     nameFormat = "camel"
   }: Options = {} as Options
 ) => {
@@ -46,7 +59,7 @@ export const fileToClassNames = (
       {
         file,
         includePaths,
-        importer: importer(aliases)
+        importer: importer(aliases, aliasPrefixes)
       },
       (err, result) => {
         if (err) {


### PR DESCRIPTION
Implements #9.

When using Webpack with sass-loader to compile scss files, the standard import syntax is `~package-name/path/to/file`, where `~` is then replaced with the string `node_modules/`. In this case, it can become very bloated to have to individually specify each imported scss file alias for these imports. Being able to define a prefix value to replace within the filename string means that a single prefix can be used to match the sass-loader/webpack import syntax for all scss imports.