### PR TITLE
Add 2 nameFormat options for use with Webpack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,17 @@ This matches the common use-case for importing scss files from node_modules when
 
 ### `--nameFormat` (`-n`)
 
-- **Type**: `"camel" | "kebab" | "param"`
+- **Type**: `"camel" | "kebab" | "param" | "dashes" | "none"`
 - **Default**: `"camel"`
 - **Example**: `tsm src --nameFormat camel`
 
 The class naming format to use when converting the classes to type definitions.
+
+- **camel**: convert all classNames to camel-case, e.g. `App-Logo` => `appLogo`.
+- **kebab**/**param**: convert all classNames to kebab/param case, e.g. `App-Logo` => `app-logo` (all lower case with '-' separators).
+- **dashes**: only convert classNames containing dashes to camel-case, leave others alone, e.g. `App` => `App`, `App-Logo` => `appLogo`. Matches the webpack [css-loader camelCase 'dashesOnly'](https://github.com/webpack-contrib/css-loader#camelcase) option.
+- **none**: do not modify the given classNames (you should use `--exportType default` when using `--nameFormat none` as any classes with a `-` in them are invalid as normal variable names).
+  Note: If you are using create-react-app v2.x and have NOT ejected, `--nameFormat none --exportType default` matches the classNames that are generated in CRA's webpack's config.
 
 ### `--listDifferent` (`-l`)
 

--- a/__tests__/core/generate.test.ts
+++ b/__tests__/core/generate.test.ts
@@ -18,6 +18,6 @@ describe("generate", () => {
       listDifferent: false
     });
 
-    expect(fs.writeFileSync).toBeCalledTimes(4);
+    expect(fs.writeFileSync).toBeCalledTimes(5);
   });
 });

--- a/__tests__/dashes.scss
+++ b/__tests__/dashes.scss
@@ -1,0 +1,11 @@
+.App {
+  background: white;
+
+  .Logo {
+    width: 50%;
+  }
+}
+
+.App-Header {
+  font-size: 2em;
+}

--- a/__tests__/dashes.scss.d.ts
+++ b/__tests__/dashes.scss.d.ts
@@ -1,0 +1,3 @@
+export const app: string;
+export const logo: string;
+export const appHeader: string;

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -18,7 +18,7 @@ describe("main", () => {
       listDifferent: false
     });
 
-    expect(fs.writeFileSync).toBeCalledTimes(4);
+    expect(fs.writeFileSync).toBeCalledTimes(5);
 
     expect(fs.writeFileSync).toBeCalledWith(
       `${__dirname}/complex.scss.d.ts`,

--- a/__tests__/sass/file-to-class-names.test.ts
+++ b/__tests__/sass/file-to-class-names.test.ts
@@ -23,6 +23,22 @@ describe("fileToClassNames", () => {
 
       expect(result).toEqual(["some-styles", "nested-class", "nested-another"]);
     });
+
+    test("it converts a file path to an array of class names where only classes with dashes in the names are altered", async () => {
+      const result = await fileToClassNames(`${__dirname}/../dashes.scss`, {
+        nameFormat: "dashes"
+      });
+
+      expect(result).toEqual(["App", "Logo", "appHeader"]);
+    });
+
+    test("it does not change class names when nameFormat is set to none", async () => {
+      const result = await fileToClassNames(`${__dirname}/../dashes.scss`, {
+        nameFormat: "none"
+      });
+
+      expect(result).toEqual(["App", "Logo", "App-Header"]);
+    });
   });
 
   describe("aliases", () => {

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -11,7 +11,7 @@ export interface Aliases {
   [index: string]: string;
 }
 
-export type NameFormat = "camel" | "kebab" | "param";
+export type NameFormat = "camel" | "kebab" | "param" | "dashes" | "none";
 
 export interface Options {
   includePaths?: string[];
@@ -20,7 +20,13 @@ export interface Options {
   nameFormat?: NameFormat;
 }
 
-export const NAME_FORMATS: NameFormat[] = ["camel", "kebab", "param"];
+export const NAME_FORMATS: NameFormat[] = [
+  "camel",
+  "kebab",
+  "param",
+  "dashes",
+  "none"
+];
 
 const importer = (aliases: Aliases, aliasPrefixes: Aliases) => (
   url: string
@@ -89,5 +95,10 @@ const classNameTransformer = (nameFormat: NameFormat): Transformer => {
       return className => paramcase(className);
     case "camel":
       return className => camelcase(className);
+    case "dashes":
+      return className =>
+        /-/.test(className) ? camelcase(className) : className;
+    case "none":
+      return className => className;
   }
 };

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -17,15 +17,19 @@ const isReservedKeyword = (className: ClassName) =>
   reserved.check(className, "es6", true);
 
 const isValidName = (className: ClassName) => {
-  const valid = !isReservedKeyword(className);
-
-  if (!valid) {
+  if (isReservedKeyword(className)) {
     alerts.warn(
       `[SKIPPING] '${className}' is a reserved keyword (consider renaming or using --exportType default).`
     );
+    return false;
+  } else if (/-/.test(className)) {
+    alerts.warn(
+      `[SKIPPING] '${className}' contains dashes (consider using 'camelCase' or 'dashes' for --nameFormat or using --exportType default).`
+    );
+    return false;
   }
 
-  return valid;
+  return true;
 };
 
 export const classNamesToTypeDefinitions = (


### PR DESCRIPTION
* dashes - matches the "dashesOnly" option from css-loader where only classNames containing a dash are converted to camel-case.
* none - projects created with create-react-app v2 use a webpack config that does not modify the classnames at all. This means that in order for webpack to find the generated classNames, the exported type names for classes must not be altered. Using `--exportType default` is required if the user has any classNames containing dashes (dashes are identified as invalid names if `--exportType named` is used and generate a warning that the classname containing a dash has been excluded).

I've tried to document how each of the nameFormat options change the original classnames, but I wasn't able to see what the difference was between `param` and `kebab`. Please let me know how to update that bit if it's not correct. :)