### PR TITLE
Export the Styles interface + ClassNames union

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,17 +157,19 @@ Given the following SCSS:
 The following type definitions will be generated:
 
 ```typescript
-interface Styles {
+export interface Styles {
   text: string;
   textHighlighted: string;
 }
+
+export type ClassNames = keyof Styles;
 
 declare const styles: Styles;
 
 export default styles;
 ```
 
-This export type is useful when using kebab (param) cased class names since variables with a `-` are not valid variables and will produce invalid types or when a class name is a TypeScript keyword (eg: `while` or `delete`)
+This export type is useful when using kebab (param) cased class names since variables with a `-` are not valid variables and will produce invalid types or when a class name is a TypeScript keyword (eg: `while` or `delete`). Additionally, the `Styles` and `ClassNames` types are exported which can be useful for properly typing variables, functions, etc. when working with dynamic class names.
 
 ## Examples
 

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -56,7 +56,7 @@ describe("classNamesToTypeDefinitions", () => {
       );
 
       expect(definition).toEqual(
-        "interface Styles {\n  'myClass': string;\n  'yourClass': string;\n}\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
+        "export interface Styles {\n  'myClass': string;\n  'yourClass': string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
       );
     });
 

--- a/examples/default-export/feature-a/index.ts
+++ b/examples/default-export/feature-a/index.ts
@@ -1,4 +1,13 @@
-import styles from "./style.scss";
+import styles, { Styles, ClassNames } from "./style.scss";
 
 console.log(styles.i);
 console.log(styles["i-am-kebab-cased"]);
+
+// Using the ClassNames union type to assign class names.
+const className: ClassNames = "i-am-kebab-cased";
+
+// Using the Styles type for reconstructing a subset.
+export const classNames: Partial<Styles> = {
+  [className]: "something",
+  i: "a-string"
+};

--- a/examples/default-export/feature-a/style.scss.d.ts
+++ b/examples/default-export/feature-a/style.scss.d.ts
@@ -1,8 +1,10 @@
-interface Styles {
+export interface Styles {
   i: string;
   "i-am-kebab-cased": string;
   while: string;
 }
+
+export type ClassNames = keyof Styles;
 
 declare const styles: Styles;
 

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -41,9 +41,10 @@ export const classNamesToTypeDefinitions = (
 
     switch (exportType) {
       case "default":
-        typeDefinitions = "interface Styles {\n";
+        typeDefinitions = "export interface Styles {\n";
         typeDefinitions += classNames.map(classNameToInterfaceKey).join("\n");
         typeDefinitions += "\n}\n\n";
+        typeDefinitions += "export type ClassNames = keyof Styles;\n\n";
         typeDefinitions += "declare const styles: Styles;\n\n";
         typeDefinitions += "export default styles;\n";
         return typeDefinitions;


### PR DESCRIPTION
Inspired from https://github.com/skovy/typed-scss-modules/issues/19.

It may be useful to have direct access to the `Styles` interface or assigning a specific class name to a variable.