### PR TITLE
feat(option): allow to skip initial build in watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ The only required argument is the directoy where all SCSS files are located. Run
 
 Watch for files that get added or are changed and generate the corresponding type definitions.
 
+### `--ignoreInitial`
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **Example**: `tsm src --watch --ignoreInitial`
+
+Skips the initial build when passing the watch flag. Use this when running concurrently with another watch, but the initial build should happen first. You would run without watch first, then start off the concurrent runs after.
+
 ### `--includePaths` (`-i`)
 
 - **Type**: `string[]`

--- a/__tests__/core/generate.test.ts
+++ b/__tests__/core/generate.test.ts
@@ -14,6 +14,7 @@ describe("generate", () => {
 
     await generate(pattern, {
       watch: false,
+      ignoreInitial: false,
       exportType: "named",
       listDifferent: false
     });

--- a/__tests__/core/list-different.test.ts
+++ b/__tests__/core/list-different.test.ts
@@ -17,6 +17,7 @@ describe("writeFile", () => {
 
     await listDifferent(pattern, {
       watch: false,
+      ignoreInitial: false,
       exportType: "named",
       listDifferent: true,
       aliases: {
@@ -40,6 +41,7 @@ describe("writeFile", () => {
 
     await listDifferent(pattern, {
       watch: false,
+      ignoreInitial: false,
       exportType: "named",
       listDifferent: true
     });

--- a/__tests__/core/write-file.test.ts
+++ b/__tests__/core/write-file.test.ts
@@ -16,6 +16,7 @@ describe("writeFile", () => {
 
     await writeFile(testFile, {
       watch: false,
+      ignoreInitial: false,
       exportType: "named",
       listDifferent: false
     });
@@ -35,6 +36,7 @@ describe("writeFile", () => {
 
     await writeFile(testFile, {
       watch: false,
+      ignoreInitial: false,
       exportType: "named",
       listDifferent: false
     });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -14,6 +14,7 @@ describe("main", () => {
 
     await main(pattern, {
       watch: false,
+      ignoreInitial: false,
       exportType: "named",
       listDifferent: false
     });

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -64,6 +64,11 @@ const { _: patterns, ...rest } = yargs
     describe:
       "Watch for added or changed files and (re-)generate the type definitions."
   })
+  .option("ignoreInitial", {
+    boolean: true,
+    default: false,
+    describe: "Skips the initial build when passing the watch flag."
+  })
   .option("listDifferent", {
     boolean: true,
     default: false,

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -5,4 +5,5 @@ export interface MainOptions extends Options {
   exportType: ExportType;
   listDifferent: boolean;
   watch: boolean;
+  ignoreInitial: boolean;
 }

--- a/lib/core/watch.ts
+++ b/lib/core/watch.ts
@@ -14,7 +14,9 @@ export const watch = (pattern: string, options: MainOptions): void => {
   alerts.success("Watching files...");
 
   chokidar
-    .watch(pattern)
+    .watch(pattern, {
+      ignoreInitial: options.ignoreInitial
+    })
     .on("change", path => {
       alerts.info(`[CHANGED] ${path}`);
       writeFile(path, options);


### PR DESCRIPTION
This adds an option to skip the initial run when using the watch param. This is useful when running concurrently with some other script (another watch, for instance), but this should finish first the first time. So you run this first, then run watch with skip initial true.