### PR TITLE
fix watch option not working on windows

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import slash from "slash";
 
 import { main } from "../lib/main";
 
@@ -19,14 +20,16 @@ describe("main", () => {
       listDifferent: false
     });
 
+    const expectedDirname = slash(__dirname);
+
     expect(fs.writeFileSync).toBeCalledTimes(5);
 
     expect(fs.writeFileSync).toBeCalledWith(
-      `${__dirname}/complex.scss.d.ts`,
+      `${expectedDirname}/complex.scss.d.ts`,
       "export const someStyles: string;\nexport const nestedClass: string;\nexport const nestedAnother: string;\n"
     );
     expect(fs.writeFileSync).toBeCalledWith(
-      `${__dirname}/style.scss.d.ts`,
+      `${expectedDirname}/style.scss.d.ts`,
       "export const someClass: string;\n"
     );
   });

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import slash from "slash";
 
 import { watch, MainOptions, generate, listDifferent } from "./core";
 
@@ -16,7 +17,7 @@ export const main = async (pattern: string, options: MainOptions) => {
     }
 
     // When the pattern provide is a directory, assume all .scss files within.
-    pattern = path.resolve(pattern, "**/*.scss");
+    pattern = slash(path.resolve(pattern, "**/*.scss"));
   }
 
   if (options.listDifferent) {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "param-case": "^2.1.1",
     "path": "^0.12.7",
     "reserved-words": "^0.1.2",
+    "slash": "^3.0.0",
     "yargs": "^12.0.5"
   },
   "husky": {


### PR DESCRIPTION
Resolves https://github.com/skovy/typed-scss-modules/issues/28

Chokidar couldn't watch files with backslashes in path, they should be replaced with forward slashes 

Quote from chokidar readme:

> Note: globs must not contain windows separators (\\), because that's how they work by the standard — you'll need to replace them with forward slashes (/).