### PR TITLE
Add required packages to npx usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ export const textHighlighted: string;
 
 ## Basic Usage
 
-Run with npm package runner:
+Run without installing:
 
 ```bash
-npx tsm src
+npx -p node-sass -p typed-scss-modules tsm src
 ```
 
 Or, install globally:


### PR DESCRIPTION
Ensures that this module and its peer dependency `node-sass` are installed by npx before executing the binary. `npx tsm` without package arguments will attempt to install the unrelated npm package named `tsm`, if the `tsm` binary is not in the path.