### PR TITLE
Support the Dart SASS package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jobs:
       script:
         - yarn check-types
         - yarn test
+        - git reset --hard HEAD
         - yarn check-formatting
         - yarn build
         - yarn commitlint-travis

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ A pattern or an array of glob patterns to exclude files that match and avoid gen
 
 An array of paths to look in to attempt to resolve your `@import` declarations. This example will search the `src/core` directory when resolving imports.
 
+### `--implementation`
+
+- **Type**: `"node-sass" | "sass"`
+- **Default**: If an option is passed, it will always use the provided package implementation. If an option is not passed, it will first check if `node-sass` is installed. If it is, it will be used. Otherwise, it will then check if `sass` is installed. If it is, it will be used. Finally, falling back to `node-sass` if all checks and validations fail.
+- **Example**: `tsm src --implementation sass`
+
 ### `--aliases` (`-a`)
 
 - **Type**: `object`

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1,0 +1,26 @@
+import { execSync } from "child_process";
+
+describe.only("cli", () => {
+  it("should run when no files are found", () => {
+    const result = execSync("yarn tsm src").toString();
+
+    expect(result).toContain("No files found.");
+  });
+
+  describe("examples", () => {
+    it("should run the basic example without errors", () => {
+      const result = execSync(
+        `yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables`
+      ).toString();
+
+      expect(result).toContain("Found 3 files. Generating type definitions...");
+    });
+    it("should run the default-export example without errors", () => {
+      const result = execSync(
+        `yarn tsm "examples/default-export/**/*.scss" --exportType default --nameFormat kebab`
+      ).toString();
+
+      expect(result).toContain("Found 1 file. Generating type definitions...");
+    });
+  });
+});

--- a/__tests__/core/generate.test.ts
+++ b/__tests__/core/generate.test.ts
@@ -1,25 +1,29 @@
 import fs from "fs";
 
 import { generate } from "../../lib/core";
+import { describeAllImplementations } from "../helpers";
 
-describe("generate", () => {
-  beforeEach(() => {
-    // Only mock the write, so the example files can still be read.
-    fs.writeFileSync = jest.fn();
-    console.log = jest.fn(); // avoid console logs showing up
-  });
-
-  test("generates types for all files matching the pattern", async () => {
-    const pattern = `${__dirname}/../**/*.scss`;
-
-    await generate(pattern, {
-      watch: false,
-      ignoreInitial: false,
-      exportType: "named",
-      listDifferent: false,
-      ignore: []
+describeAllImplementations(implementation => {
+  describe("generate", () => {
+    beforeEach(() => {
+      // Only mock the write, so the example files can still be read.
+      fs.writeFileSync = jest.fn();
+      console.log = jest.fn(); // avoid console logs showing up
     });
 
-    expect(fs.writeFileSync).toBeCalledTimes(5);
+    test("generates types for all files matching the pattern", async () => {
+      const pattern = `${__dirname}/../**/*.scss`;
+
+      await generate(pattern, {
+        watch: false,
+        ignoreInitial: false,
+        exportType: "named",
+        listDifferent: false,
+        ignore: [],
+        implementation
+      });
+
+      expect(fs.writeFileSync).toBeCalledTimes(5);
+    });
   });
 });

--- a/__tests__/core/list-different.test.ts
+++ b/__tests__/core/list-different.test.ts
@@ -1,54 +1,62 @@
 import { listDifferent } from "../../lib/core";
 
-describe("writeFile", () => {
-  let exit: jest.SpyInstance;
+import { describeAllImplementations } from "../helpers";
 
-  beforeEach(() => {
-    console.log = jest.fn();
-    exit = jest.spyOn(process, "exit").mockImplementation();
-  });
+describeAllImplementations(implementation => {
+  describe("writeFile", () => {
+    let exit: jest.SpyInstance;
 
-  afterEach(() => {
-    exit.mockRestore();
-  });
-
-  test("logs invalid type definitions and exits with 1", async () => {
-    const pattern = `${__dirname}/../**/*.scss`;
-
-    await listDifferent(pattern, {
-      watch: false,
-      ignoreInitial: false,
-      exportType: "named",
-      listDifferent: true,
-      aliases: {
-        "~fancy-import": "complex",
-        "~another": "style"
-      },
-      aliasPrefixes: {
-        "~": "nested-styles/"
-      },
-      ignore: []
+    beforeEach(() => {
+      console.log = jest.fn();
+      exit = jest.spyOn(process, "exit").mockImplementation();
     });
 
-    expect(exit).toHaveBeenCalledWith(1);
-    expect(console.log).toBeCalledWith(
-      expect.stringContaining(`[INVALID TYPES] Check type definitions for`)
-    );
-    expect(console.log).toBeCalledWith(expect.stringContaining(`invalid.scss`));
-  });
-
-  test("logs nothing and does not exit if all files are valid", async () => {
-    const pattern = `${__dirname}/../**/style.scss`;
-
-    await listDifferent(pattern, {
-      watch: false,
-      ignoreInitial: false,
-      exportType: "named",
-      listDifferent: true,
-      ignore: []
+    afterEach(() => {
+      exit.mockRestore();
     });
 
-    expect(exit).not.toHaveBeenCalled();
-    expect(console.log).not.toHaveBeenCalled();
+    test("logs invalid type definitions and exits with 1", async () => {
+      const pattern = `${__dirname}/../**/*.scss`;
+
+      await listDifferent(pattern, {
+        watch: false,
+        ignoreInitial: false,
+        exportType: "named",
+        listDifferent: true,
+        aliases: {
+          "~fancy-import": "complex",
+          "~another": "style"
+        },
+        aliasPrefixes: {
+          "~": "nested-styles/"
+        },
+        ignore: [],
+        implementation
+      });
+
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(console.log).toBeCalledWith(
+        expect.stringContaining(`[INVALID TYPES] Check type definitions for`)
+      );
+      expect(console.log).toBeCalledWith(
+        expect.stringContaining(`invalid.scss`)
+      );
+    });
+
+    test("logs nothing and does not exit if all files are valid", async () => {
+      const pattern = `${__dirname}/../**/style.scss`;
+
+      await listDifferent(pattern, {
+        watch: false,
+        ignoreInitial: false,
+        exportType: "named",
+        listDifferent: true,
+        ignore: [],
+        implementation
+      });
+
+      expect(exit).not.toHaveBeenCalled();
+      expect(console.log).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/core/write-file.test.ts
+++ b/__tests__/core/write-file.test.ts
@@ -3,50 +3,56 @@ import fs from "fs";
 import { writeFile } from "../../lib/core";
 import { getTypeDefinitionPath } from "../../lib/typescript";
 
-describe("writeFile", () => {
-  beforeEach(() => {
-    // Only mock the write, so the example files can still be read.
-    fs.writeFileSync = jest.fn();
-    console.log = jest.fn();
-  });
+import { describeAllImplementations } from "../helpers";
 
-  test("writes the corresponding type definitions for a file and logs", async () => {
-    const testFile = `${__dirname}/../style.scss`;
-    const typesFile = getTypeDefinitionPath(testFile);
-
-    await writeFile(testFile, {
-      watch: false,
-      ignoreInitial: false,
-      exportType: "named",
-      listDifferent: false,
-      ignore: []
+describeAllImplementations(implementation => {
+  describe("writeFile", () => {
+    beforeEach(() => {
+      // Only mock the write, so the example files can still be read.
+      fs.writeFileSync = jest.fn();
+      console.log = jest.fn();
     });
 
-    expect(fs.writeFileSync).toBeCalledWith(
-      typesFile,
-      "export const someClass: string;\n"
-    );
+    test("writes the corresponding type definitions for a file and logs", async () => {
+      const testFile = `${__dirname}/../style.scss`;
+      const typesFile = getTypeDefinitionPath(testFile);
 
-    expect(console.log).toBeCalledWith(
-      expect.stringContaining(`[GENERATED TYPES] ${typesFile}`)
-    );
-  });
+      await writeFile(testFile, {
+        watch: false,
+        ignoreInitial: false,
+        exportType: "named",
+        listDifferent: false,
+        ignore: [],
+        implementation
+      });
 
-  test("it skips files with no classes", async () => {
-    const testFile = `${__dirname}/../empty.scss`;
+      expect(fs.writeFileSync).toBeCalledWith(
+        typesFile,
+        "export const someClass: string;\n"
+      );
 
-    await writeFile(testFile, {
-      watch: false,
-      ignoreInitial: false,
-      exportType: "named",
-      listDifferent: false,
-      ignore: []
+      expect(console.log).toBeCalledWith(
+        expect.stringContaining(`[GENERATED TYPES] ${typesFile}`)
+      );
     });
 
-    expect(fs.writeFileSync).not.toBeCalled();
+    test("it skips files with no classes", async () => {
+      const testFile = `${__dirname}/../empty.scss`;
 
-    expect(console.log).toBeCalledWith(
-      expect.stringContaining(`[NO GENERATED TYPES] ${testFile}`)
-    );
+      await writeFile(testFile, {
+        watch: false,
+        ignoreInitial: false,
+        exportType: "named",
+        listDifferent: false,
+        ignore: [],
+        implementation
+      });
+
+      expect(fs.writeFileSync).not.toBeCalled();
+
+      expect(console.log).toBeCalledWith(
+        expect.stringContaining(`[NO GENERATED TYPES] ${testFile}`)
+      );
+    });
   });
 });

--- a/__tests__/helpers/index.ts
+++ b/__tests__/helpers/index.ts
@@ -1,0 +1,9 @@
+import { Implementations, IMPLEMENTATIONS } from "../../lib/implementations";
+
+export const describeAllImplementations = (
+  fn: (implementation: Implementations) => void
+) => {
+  IMPLEMENTATIONS.forEach(implementation => {
+    describe(`${implementation} implementation`, () => fn(implementation));
+  });
+};

--- a/__tests__/implementations/get-default-implementation.test.ts
+++ b/__tests__/implementations/get-default-implementation.test.ts
@@ -1,0 +1,31 @@
+import { getDefaultImplementation } from "../../lib/implementations";
+
+describe("getDefaultImplementation", () => {
+  it("returns node-sass if it exists", () => {
+    expect(getDefaultImplementation()).toBe("node-sass");
+  });
+
+  it("returns sass if node-sass does not exist", () => {
+    const resolver = (jest.fn(implementation => {
+      if (implementation === "node-sass") {
+        throw new Error("Not Found");
+      }
+    }) as unknown) as RequireResolve;
+
+    expect(getDefaultImplementation(resolver)).toBe("sass");
+    expect(resolver).toHaveBeenCalledTimes(2);
+    expect(resolver).toHaveBeenNthCalledWith(1, "node-sass");
+    expect(resolver).toHaveBeenNthCalledWith(2, "sass");
+  });
+
+  it("returns node-sass even if both sass and node-sass do not exist", () => {
+    const resolver = (jest.fn(() => {
+      throw new Error("Not Found");
+    }) as unknown) as RequireResolve;
+
+    expect(getDefaultImplementation(resolver)).toBe("node-sass");
+    expect(resolver).toHaveBeenCalledTimes(2);
+    expect(resolver).toHaveBeenNthCalledWith(1, "node-sass");
+    expect(resolver).toHaveBeenNthCalledWith(2, "sass");
+  });
+});

--- a/__tests__/implementations/get-implementation.test.ts
+++ b/__tests__/implementations/get-implementation.test.ts
@@ -1,0 +1,16 @@
+import sass from "sass";
+import nodeSass from "node-sass";
+
+import { getImplementation } from "../../lib/implementations";
+
+describe("getImplementation", () => {
+  it("returns the correct implementation when explicitly passed", () => {
+    expect(getImplementation("node-sass")).toEqual(nodeSass);
+    expect(getImplementation("sass")).toEqual(sass);
+  });
+
+  it("returns the correct default implementation if it is invalid", () => {
+    expect(getImplementation("wat-sass" as any)).toEqual(nodeSass);
+    expect(getImplementation()).toEqual(nodeSass);
+  });
+});

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -2,66 +2,71 @@ import fs from "fs";
 import slash from "slash";
 
 import { main } from "../lib/main";
+import { describeAllImplementations } from "./helpers";
 
-describe("main", () => {
-  beforeEach(() => {
-    // Only mock the write, so the example files can still be read.
-    fs.writeFileSync = jest.fn();
-    console.log = jest.fn(); // avoid console logs showing up
-  });
-
-  test("generates types for all .scss files when the pattern is a directory", async () => {
-    const pattern = `${__dirname}`;
-
-    await main(pattern, {
-      watch: false,
-      ignoreInitial: false,
-      exportType: "named",
-      listDifferent: false,
-      ignore: []
+describeAllImplementations(implementation => {
+  describe("main", () => {
+    beforeEach(() => {
+      // Only mock the write, so the example files can still be read.
+      fs.writeFileSync = jest.fn();
+      console.log = jest.fn(); // avoid console logs showing up
     });
 
-    const expectedDirname = slash(__dirname);
+    test("generates types for all .scss files when the pattern is a directory", async () => {
+      const pattern = `${__dirname}`;
 
-    expect(fs.writeFileSync).toBeCalledTimes(5);
+      await main(pattern, {
+        watch: false,
+        ignoreInitial: false,
+        exportType: "named",
+        listDifferent: false,
+        ignore: [],
+        implementation
+      });
 
-    expect(fs.writeFileSync).toBeCalledWith(
-      `${expectedDirname}/complex.scss.d.ts`,
-      "export const someStyles: string;\nexport const nestedClass: string;\nexport const nestedAnother: string;\n"
-    );
-    expect(fs.writeFileSync).toBeCalledWith(
-      `${expectedDirname}/style.scss.d.ts`,
-      "export const someClass: string;\n"
-    );
-  });
+      const expectedDirname = slash(__dirname);
 
-  test("generates types for all .scss files and ignores files that match the ignore pattern", async () => {
-    const pattern = `${__dirname}`;
+      expect(fs.writeFileSync).toBeCalledTimes(5);
 
-    await main(pattern, {
-      watch: false,
-      ignoreInitial: false,
-      exportType: "named",
-      listDifferent: false,
-      ignore: ["**/style.scss"]
+      expect(fs.writeFileSync).toBeCalledWith(
+        `${expectedDirname}/complex.scss.d.ts`,
+        "export const someStyles: string;\nexport const nestedClass: string;\nexport const nestedAnother: string;\n"
+      );
+      expect(fs.writeFileSync).toBeCalledWith(
+        `${expectedDirname}/style.scss.d.ts`,
+        "export const someClass: string;\n"
+      );
     });
 
-    expect(fs.writeFileSync).toBeCalledTimes(3);
+    test("generates types for all .scss files and ignores files that match the ignore pattern", async () => {
+      const pattern = `${__dirname}`;
 
-    const expectedDirname = slash(__dirname);
-    expect(fs.writeFileSync).toBeCalledWith(
-      `${expectedDirname}/complex.scss.d.ts`,
-      "export const someStyles: string;\nexport const nestedClass: string;\nexport const nestedAnother: string;\n"
-    );
+      await main(pattern, {
+        watch: false,
+        ignoreInitial: false,
+        exportType: "named",
+        listDifferent: false,
+        ignore: ["**/style.scss"],
+        implementation
+      });
 
-    // Files that should match the ignore pattern.
-    expect(fs.writeFileSync).not.toBeCalledWith(
-      `${expectedDirname}/style.scss.d.ts`,
-      expect.anything()
-    );
-    expect(fs.writeFileSync).not.toBeCalledWith(
-      `${expectedDirname}/nested-styles/style.scss.d.ts`,
-      expect.anything()
-    );
+      expect(fs.writeFileSync).toBeCalledTimes(3);
+
+      const expectedDirname = slash(__dirname);
+      expect(fs.writeFileSync).toBeCalledWith(
+        `${expectedDirname}/complex.scss.d.ts`,
+        "export const someStyles: string;\nexport const nestedClass: string;\nexport const nestedAnother: string;\n"
+      );
+
+      // Files that should match the ignore pattern.
+      expect(fs.writeFileSync).not.toBeCalledWith(
+        `${expectedDirname}/style.scss.d.ts`,
+        expect.anything()
+      );
+      expect(fs.writeFileSync).not.toBeCalledWith(
+        `${expectedDirname}/nested-styles/style.scss.d.ts`,
+        expect.anything()
+      );
+    });
   });
 });

--- a/__tests__/sass/file-to-class-names.test.ts
+++ b/__tests__/sass/file-to-class-names.test.ts
@@ -1,86 +1,104 @@
 import { fileToClassNames } from "../../lib/sass";
 
-describe("fileToClassNames", () => {
-  test("it converts a file path to an array of class names (default camel cased)", async () => {
-    const result = await fileToClassNames(`${__dirname}/../complex.scss`);
+import { describeAllImplementations } from "../helpers";
 
-    expect(result).toEqual(["someStyles", "nestedClass", "nestedAnother"]);
-  });
+describeAllImplementations(implementation => {
+  describe("fileToClassNames", () => {
+    test("it converts a file path to an array of class names (default camel cased)", async () => {
+      const result = await fileToClassNames(`${__dirname}/../complex.scss`);
 
-  describe("nameFormat", () => {
-    test("it converts a file path to an array of class names with kebab as the name format", async () => {
-      const result = await fileToClassNames(`${__dirname}/../complex.scss`, {
-        nameFormat: "kebab"
-      });
-
-      expect(result).toEqual(["some-styles", "nested-class", "nested-another"]);
+      expect(result).toEqual(["someStyles", "nestedClass", "nestedAnother"]);
     });
 
-    test("it converts a file path to an array of class names with param as the name format", async () => {
-      const result = await fileToClassNames(`${__dirname}/../complex.scss`, {
-        nameFormat: "param"
+    describe("nameFormat", () => {
+      test("it converts a file path to an array of class names with kebab as the name format", async () => {
+        const result = await fileToClassNames(`${__dirname}/../complex.scss`, {
+          nameFormat: "kebab",
+          implementation
+        });
+
+        expect(result).toEqual([
+          "some-styles",
+          "nested-class",
+          "nested-another"
+        ]);
       });
 
-      expect(result).toEqual(["some-styles", "nested-class", "nested-another"]);
-    });
+      test("it converts a file path to an array of class names with param as the name format", async () => {
+        const result = await fileToClassNames(`${__dirname}/../complex.scss`, {
+          nameFormat: "param",
+          implementation
+        });
 
-    test("it converts a file path to an array of class names where only classes with dashes in the names are altered", async () => {
-      const result = await fileToClassNames(`${__dirname}/../dashes.scss`, {
-        nameFormat: "dashes"
+        expect(result).toEqual([
+          "some-styles",
+          "nested-class",
+          "nested-another"
+        ]);
       });
 
-      expect(result).toEqual(["App", "Logo", "appHeader"]);
-    });
+      test("it converts a file path to an array of class names where only classes with dashes in the names are altered", async () => {
+        const result = await fileToClassNames(`${__dirname}/../dashes.scss`, {
+          nameFormat: "dashes",
+          implementation
+        });
 
-    test("it does not change class names when nameFormat is set to none", async () => {
-      const result = await fileToClassNames(`${__dirname}/../dashes.scss`, {
-        nameFormat: "none"
+        expect(result).toEqual(["App", "Logo", "appHeader"]);
       });
 
-      expect(result).toEqual(["App", "Logo", "App-Header"]);
-    });
-  });
+      test("it does not change class names when nameFormat is set to none", async () => {
+        const result = await fileToClassNames(`${__dirname}/../dashes.scss`, {
+          nameFormat: "none",
+          implementation
+        });
 
-  describe("aliases", () => {
-    test("it converts a file that contains aliases", async () => {
-      const result = await fileToClassNames(`${__dirname}/../aliases.scss`, {
-        aliases: {
-          "~fancy-import": "complex",
-          "~another": "style"
-        }
+        expect(result).toEqual(["App", "Logo", "App-Header"]);
       });
-
-      expect(result).toEqual([
-        "someStyles",
-        "nestedClass",
-        "nestedAnother",
-        "someClass",
-        "myCustomClass"
-      ]);
     });
-  });
 
-  describe("aliasPrefixes", () => {
-    test("it converts a file that contains alias prefixes (but prioritizes aliases)", async () => {
-      const result = await fileToClassNames(
-        `${__dirname}/../alias-prefixes.scss`,
-        {
+    describe("aliases", () => {
+      test("it converts a file that contains aliases", async () => {
+        const result = await fileToClassNames(`${__dirname}/../aliases.scss`, {
           aliases: {
-            "~fancy-import": "complex"
+            "~fancy-import": "complex",
+            "~another": "style"
           },
-          aliasPrefixes: {
-            "~": "nested-styles/"
-          }
-        }
-      );
+          implementation
+        });
 
-      expect(result).toEqual([
-        "someStyles",
-        "nestedClass",
-        "nestedAnother",
-        "nestedStyles",
-        "myCustomClass"
-      ]);
+        expect(result).toEqual([
+          "someStyles",
+          "nestedClass",
+          "nestedAnother",
+          "someClass",
+          "myCustomClass"
+        ]);
+      });
+    });
+
+    describe("aliasPrefixes", () => {
+      test("it converts a file that contains alias prefixes (but prioritizes aliases)", async () => {
+        const result = await fileToClassNames(
+          `${__dirname}/../alias-prefixes.scss`,
+          {
+            aliases: {
+              "~fancy-import": "complex"
+            },
+            aliasPrefixes: {
+              "~": "nested-styles/"
+            },
+            implementation
+          }
+        );
+
+        expect(result).toEqual([
+          "someStyles",
+          "nestedClass",
+          "nestedAnother",
+          "nestedStyles",
+          "myCustomClass"
+        ]);
+      });
     });
   });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testMatch: ["**/__tests__/**/*.test.ts?(x)"],
   testPathIgnorePatterns: [
     "<rootDir>/dist/",
     "<rootDir>/node_modules/",

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -5,6 +5,7 @@ import yargs from "yargs";
 import { Aliases, NAME_FORMATS, NameFormat } from "./sass";
 import { ExportType, EXPORT_TYPES } from "./typescript";
 import { main } from "./main";
+import { IMPLEMENTATIONS, getDefaultImplementation } from "./implementations";
 
 const nameFormatDefault: NameFormat = "camel";
 const exportTypeDefault: ExportType = "named";
@@ -38,6 +39,10 @@ const { _: patterns, ...rest } = yargs
     "$0 src/**/*.scss --ignore **/secret.scss",
     'Ignore any file names "secret.scss"'
   )
+  .example(
+    "$0 src/**/*.scss --implementation sass",
+    "Use the Dart SASS package"
+  )
   .demandCommand(1)
   .option("aliases", {
     coerce: (obj): Aliases => obj,
@@ -55,11 +60,17 @@ const { _: patterns, ...rest } = yargs
     alias: "n",
     describe: "The name format that should be used to transform class names."
   })
+  .option("implementation", {
+    choices: IMPLEMENTATIONS,
+    default: getDefaultImplementation(),
+    describe:
+      "The SASS package to used to compile. This will default to the sass implementation you have installed."
+  })
   .option("exportType", {
     choices: EXPORT_TYPES,
     default: exportTypeDefault,
     alias: "e",
-    describe: "The type of export used for defining the type defintions."
+    describe: "The type of export used for defining the type definitions."
   })
   .option("watch", {
     boolean: true,

--- a/lib/core/generate.ts
+++ b/lib/core/generate.ts
@@ -30,7 +30,11 @@ export const generate = async (
     );
   }
 
-  alerts.success(`Found ${files.length} files. Generating type definitions...`);
+  alerts.success(
+    `Found ${files.length} file${
+      files.length === 1 ? `` : `s`
+    }. Generating type definitions...`
+  );
 
   // Wait for all the type definitions to be written.
   await Promise.all(files.map(file => writeFile(file, options)));

--- a/lib/implementations/index.ts
+++ b/lib/implementations/index.ts
@@ -12,6 +12,12 @@ export type Implementations = typeof IMPLEMENTATIONS[number];
 
 type Implementation = typeof nodeSass | typeof sass;
 
+/**
+ * Determine which default implementation to use by checking which packages
+ * are actually installed and available to use.
+ *
+ * @param resolver DO NOT USE - this is unfortunately necessary only for testing.
+ */
 export const getDefaultImplementation = (
   resolver: RequireResolve = require.resolve
 ): Implementations => {

--- a/lib/implementations/index.ts
+++ b/lib/implementations/index.ts
@@ -1,0 +1,47 @@
+import nodeSass from "node-sass";
+import sass from "node-sass";
+
+/**
+ * A list of all possible SASS package implementations that can be used to
+ * perform the compilation and parsing of the SASS files. The expectation is
+ * that they provide a nearly identical API so they can be swapped out but
+ * all of the same logic can be reused.
+ */
+export const IMPLEMENTATIONS = ["node-sass", "sass"] as const;
+export type Implementations = typeof IMPLEMENTATIONS[number];
+
+type Implementation = typeof nodeSass | typeof sass;
+
+export const getDefaultImplementation = (
+  resolver: RequireResolve = require.resolve
+): Implementations => {
+  let pkg: Implementations = "node-sass";
+
+  try {
+    resolver("node-sass");
+  } catch (error) {
+    try {
+      resolver("sass");
+      pkg = "sass";
+    } catch (ignoreError) {
+      pkg = "node-sass";
+    }
+  }
+
+  return pkg;
+};
+
+/**
+ * Retrieve the desired implementation.
+ *
+ * @param implementation the desired implementation.
+ */
+export const getImplementation = (
+  implementation?: Implementations
+): Implementation => {
+  if (implementation === "sass") {
+    return require("sass");
+  } else {
+    return require("node-sass");
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-scss-modules",
-  "version": "0.0.13",
+  "version": "0.0.0",
   "description": "TypeScript type definition generator for SCSS CSS Modules",
   "main": "index.js",
   "author": "Spencer Miskoviak <smiskoviak@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -46,19 +46,30 @@
     "@types/node-sass": "^3.10.32",
     "@types/param-case": "^1.1.2",
     "@types/reserved-words": "^0.1.0",
+    "@types/sass": "^1.16.0",
     "@types/yargs": "^12.0.8",
     "husky": "^1.3.1",
     "jest": "23.6.0",
     "lint-staged": "^8.1.3",
     "node-sass": "^4.11.0",
     "prettier": "^1.16.4",
+    "sass": "^1.25.0",
     "semantic-release": "^15.13.31",
     "ts-jest": "^23.10.5",
     "ts-node": "^8.0.2",
     "typescript": "^3.3.3"
   },
   "peerDependencies": {
-    "node-sass": "^4.11.0"
+    "node-sass": "^4.11.0",
+    "sass": "^1.25.0"
+  },
+  "peerDependenciesMeta": {
+    "node-sass": {
+      "optional": true
+    },
+    "sass": {
+      "optional": true
+    }
   },
   "dependencies": {
     "camelcase": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,6 +466,13 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@types/sass@^1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.16.0.tgz#b41ac1c17fa68ffb57d43e2360486ef526b3d57d"
+  integrity sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/semver@^6.0.1":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"
@@ -1302,6 +1309,21 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+"chokidar@>=2.0.0 <4.0.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
+  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.3.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.0.tgz#12c0714668c55800f659e262d4962a97faf554a6"
@@ -1861,7 +1883,7 @@ debug@^4.0.0, debug@^4.0.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -2621,7 +2643,7 @@ fsevents@^1.2.3:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fsevents@~2.1.1:
+fsevents@~2.1.1, fsevents@~2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
   integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
@@ -3150,7 +3172,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4482,11 +4504,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4495,32 +4512,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -4566,11 +4561,6 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -5449,7 +5439,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -5464,7 +5453,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.5"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -5483,14 +5471,8 @@ npm@^6.10.3:
     libnpx "^10.2.0"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -6037,6 +6019,11 @@ picomatch@^2.0.4, picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
   integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
 
+picomatch@^2.0.7:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
+  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -6513,6 +6500,13 @@ readdirp@~3.2.0:
   dependencies:
     picomatch "^2.0.4"
 
+readdirp@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
+  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
+  dependencies:
+    picomatch "^2.0.7"
+
 readline2@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
@@ -6882,6 +6876,13 @@ sass-graph@^2.2.4:
     lodash "^4.0.0"
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
+
+sass@^1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.25.0.tgz#f8bd7dfbb39d6b0305e27704a8ebe637820693f3"
+  integrity sha512-uQMjye0Y70SEDGO56n0j91tauqS9E1BmpKHtiYNQScXDHeaE9uHwNEqQNFf4Bes/3DHMNinB6u79JsG10XWNyw==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
 
 sax@^1.2.4:
   version "1.2.4"


### PR DESCRIPTION
Resolves https://github.com/skovy/typed-scss-modules/issues/43.

# Problem

The Dart SASS and Node SASS implementations should be compatible (tested via unit tests) and folks may choose to use those interchangably. However, `typed-scss-modules` currently doesn't support both options.

# Solution

- [x] Add `sass` as a development dependency as well as an **optional** peer dependency using [`peerDependenciesMeta`](https://yarnpkg.com/en/docs/package-json#peerdependenciesmeta-). This also adds `node-sass` as an optional peer dependency. This is _less_ restrictive so it won't be considered a breaking change. Although both are optional _one_ of them will be required. There isn't a way to properly reflect this in `package.json` (that I'm aware of).
- [x] Run all unit tests against both implementations.
- [x] Use a strategy similar to the webpack [`sass-loader`](https://github.com/webpack-contrib/sass-loader#implementation). 
    - Use the package name passed in as the `implementation` option (`sass` or `node-sass`).
    - Else, try to load either package and use the implementation (`node-sass` or `sass`) defined in `node_modules`. If they both exist, it will use `node-sass`.
    - Else, if none are found, use `node-sass` (probably will error but we need some implementation).
- [x] Update the README with proper documentation.

# Testing

- Added a `console.log` to the `renderSync` methods in `node-sass` (`lib/index.js:387`) and `sass` (`sass.dart.js:10684`) packages to validate the proper packages were being installed.
- Then, ran the following examples with various options:
```
> yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables
yarn run v1.21.1
$ ts-node ./lib/cli.ts 'examples/basic/**/*.scss' --includePaths examples/basic/core '--aliases.~alias' variables
Found 3 files. Generating type definitions...
NODE-SASS renderSync
NODE-SASS renderSync
NODE-SASS renderSync
[NO GENERATED TYPES] examples/basic/core/variables.scss
[GENERATED TYPES] examples/basic/feature-a/style.scss.d.ts
[GENERATED TYPES] examples/basic/feature-b/style.scss.d.ts
✨  Done in 5.58s.

> yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables --implementation sass
yarn run v1.21.1
$ ts-node ./lib/cli.ts 'examples/basic/**/*.scss' --includePaths examples/basic/core '--aliases.~alias' variables --implementation sass
Found 3 files. Generating type definitions...
SASS renderSync
SASS renderSync
SASS renderSync
[NO GENERATED TYPES] examples/basic/core/variables.scss
[GENERATED TYPES] examples/basic/feature-a/style.scss.d.ts
[GENERATED TYPES] examples/basic/feature-b/style.scss.d.ts
✨  Done in 5.98s.

> yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables --implementation node-sass
yarn run v1.21.1
$ ts-node ./lib/cli.ts 'examples/basic/**/*.scss' --includePaths examples/basic/core '--aliases.~alias' variables --implementation node-sass
Found 3 files. Generating type definitions...
NODE-SASS renderSync
NODE-SASS renderSync
NODE-SASS renderSync
[NO GENERATED TYPES] examples/basic/core/variables.scss
[GENERATED TYPES] examples/basic/feature-a/style.scss.d.ts
[GENERATED TYPES] examples/basic/feature-b/style.scss.d.ts
✨  Done in 8.99s.
```
- Removed the `node-sass` implementation: `rm -rf node_modules/node-sass`
- Then ran the example code to validate it fallsback to `sass`:
```
> yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables
yarn run v1.21.1
$ ts-node ./lib/cli.ts 'examples/basic/**/*.scss' --includePaths examples/basic/core '--aliases.~alias' variables
Found 3 files. Generating type definitions...
SASS renderSync
SASS renderSync
SASS renderSync
[NO GENERATED TYPES] examples/basic/core/variables.scss
[GENERATED TYPES] examples/basic/feature-a/style.scss.d.ts
[GENERATED TYPES] examples/basic/feature-b/style.scss.d.ts
✨  Done in 7.86s.
```