### PR TITLE
feat(quotetype): implement the quoteType option

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ export default styles;
 
 This export type is useful when using kebab (param) cased class names since variables with a `-` are not valid variables and will produce invalid types or when a class name is a TypeScript keyword (eg: `while` or `delete`). Additionally, the `Styles` and `ClassNames` types are exported which can be useful for properly typing variables, functions, etc. when working with dynamic class names.
 
+### `--quoteType` (`-q`)
+
+- **Type**: `string`
+- **Default**: `single`
+- **Example**: `tsm src --exportType default --quoteType double`
+
+Specify a quote type to match your TypeScript configuration. Only default exports are affected by this command. This example will wrap class names with double quotes (").
+
 ## Examples
 
 For examples, see the `examples` directory:

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ This export type is useful when using kebab (param) cased class names since vari
 
 ### `--quoteType` (`-q`)
 
-- **Type**: `string`
-- **Default**: `single`
+- **Type**: `"single" | "double"`
+- **Default**: `"single"`
 - **Example**: `tsm src --exportType default --quoteType double`
 
 Specify a quote type to match your TypeScript configuration. Only default exports are affected by this command. This example will wrap class names with double quotes (").

--- a/__tests__/core/generate.test.ts
+++ b/__tests__/core/generate.test.ts
@@ -20,7 +20,8 @@ describeAllImplementations(implementation => {
         exportType: "named",
         listDifferent: false,
         ignore: [],
-        implementation
+        implementation,
+        quoteType: "single"
       });
 
       expect(fs.writeFileSync).toBeCalledTimes(5);

--- a/__tests__/core/list-different.test.ts
+++ b/__tests__/core/list-different.test.ts
@@ -31,7 +31,8 @@ describeAllImplementations(implementation => {
           "~": "nested-styles/"
         },
         ignore: [],
-        implementation
+        implementation,
+        quoteType: "single"
       });
 
       expect(exit).toHaveBeenCalledWith(1);
@@ -52,7 +53,8 @@ describeAllImplementations(implementation => {
         exportType: "named",
         listDifferent: true,
         ignore: [],
-        implementation
+        implementation,
+        quoteType: "single"
       });
 
       expect(exit).not.toHaveBeenCalled();

--- a/__tests__/core/write-file.test.ts
+++ b/__tests__/core/write-file.test.ts
@@ -23,7 +23,8 @@ describeAllImplementations(implementation => {
         exportType: "named",
         listDifferent: false,
         ignore: [],
-        implementation
+        implementation,
+        quoteType: "single"
       });
 
       expect(fs.writeFileSync).toBeCalledWith(
@@ -45,7 +46,8 @@ describeAllImplementations(implementation => {
         exportType: "named",
         listDifferent: false,
         ignore: [],
-        implementation
+        implementation,
+        quoteType: "single"
       });
 
       expect(fs.writeFileSync).not.toBeCalled();

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -21,7 +21,8 @@ describeAllImplementations(implementation => {
         exportType: "named",
         listDifferent: false,
         ignore: [],
-        implementation
+        implementation,
+        quoteType: "single"
       });
 
       const expectedDirname = slash(__dirname);
@@ -47,7 +48,8 @@ describeAllImplementations(implementation => {
         exportType: "named",
         listDifferent: false,
         ignore: ["**/style.scss"],
-        implementation
+        implementation,
+        quoteType: "single"
       });
 
       expect(fs.writeFileSync).toBeCalledTimes(3);

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -77,4 +77,29 @@ describe("classNamesToTypeDefinitions", () => {
       expect(definition).toBeNull;
     });
   });
+
+  describe("quoteType", () => {
+    it("uses double quotes for default exports when specified", () => {
+      const definition = classNamesToTypeDefinitions(
+        ["myClass", "yourClass"],
+        "default",
+        "double"
+      );
+
+      expect(definition).toEqual(
+        'export interface Styles {\n  "myClass": string;\n  "yourClass": string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n'
+      );
+    });
+    it("does not affect named exports", () => {
+      const definition = classNamesToTypeDefinitions(
+        ["myClass", "yourClass"],
+        "named",
+        "double"
+      );
+
+      expect(definition).toEqual(
+        "export const myClass: string;\nexport const yourClass: string;\n"
+      );
+    });
+  });
 });

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -3,12 +3,13 @@
 import yargs from "yargs";
 
 import { Aliases, NAME_FORMATS, NameFormat } from "./sass";
-import { ExportType, EXPORT_TYPES } from "./typescript";
+import { ExportType, EXPORT_TYPES, QuoteType, QUOTE_TYPES } from "./typescript";
 import { main } from "./main";
 import { IMPLEMENTATIONS, getDefaultImplementation } from "./implementations";
 
 const nameFormatDefault: NameFormat = "camel";
 const exportTypeDefault: ExportType = "named";
+const quoteTypeDefault: QuoteType = "single";
 
 const { _: patterns, ...rest } = yargs
   .usage(
@@ -42,6 +43,10 @@ const { _: patterns, ...rest } = yargs
   .example(
     "$0 src/**/*.scss --implementation sass",
     "Use the Dart SASS package"
+  )
+  .example(
+    "$0 src/**/*.scss -e default --quoteType double",
+    "Use double quotes around class name definitions rather than single quotes."
   )
   .demandCommand(1)
   .option("aliases", {
@@ -102,6 +107,14 @@ const { _: patterns, ...rest } = yargs
     array: true,
     default: [],
     describe: "Add a pattern or an array of glob patterns to exclude matches."
+  })
+  .options("quoteType", {
+    string: true,
+    choices: QUOTE_TYPES,
+    default: quoteTypeDefault,
+    alias: "q",
+    describe:
+      "Specify the quote type so that generated files adhere to your TypeScript rules."
   }).argv;
 
 main(patterns[0], { ...rest });

--- a/lib/core/list-different.ts
+++ b/lib/core/list-different.ts
@@ -37,7 +37,8 @@ export const checkFile = (
     fileToClassNames(file, options).then(classNames => {
       const typeDefinition = classNamesToTypeDefinitions(
         classNames,
-        options.exportType
+        options.exportType,
+        options.quoteType
       );
 
       if (!typeDefinition) {

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -1,5 +1,5 @@
 import { Options } from "../sass";
-import { ExportType } from "../typescript";
+import { ExportType, QuoteType } from "../typescript";
 
 export interface MainOptions extends Options {
   ignore: string[];
@@ -7,4 +7,5 @@ export interface MainOptions extends Options {
   listDifferent: boolean;
   watch: boolean;
   ignoreInitial: boolean;
+  quoteType: QuoteType;
 }

--- a/lib/core/write-file.ts
+++ b/lib/core/write-file.ts
@@ -23,7 +23,8 @@ export const writeFile = (
     .then(classNames => {
       const typeDefinition = classNamesToTypeDefinitions(
         classNames,
-        options.exportType
+        options.exportType,
+        options.quoteType
       );
 
       if (!typeDefinition) {

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -6,11 +6,19 @@ import { alerts } from "../core";
 export type ExportType = "named" | "default";
 export const EXPORT_TYPES: ExportType[] = ["named", "default"];
 
+export type QuoteType = "single" | "double";
+export const QUOTE_TYPES: QuoteType[] = ["single", "double"];
+
 const classNameToNamedTypeDefinition = (className: ClassName) =>
   `export const ${className}: string;`;
 
-const classNameToInterfaceKey = (className: ClassName) =>
-  `  '${className}': string;`;
+const classNameToInterfaceKey = (
+  className: ClassName,
+  quoteType: QuoteType
+) => {
+  const quote = quoteType === "single" ? "'" : '"';
+  return `  ${quote}${className}${quote}: string;`;
+};
 
 const isReservedKeyword = (className: ClassName) =>
   reserved.check(className, "es5", true) ||
@@ -34,7 +42,8 @@ const isValidName = (className: ClassName) => {
 
 export const classNamesToTypeDefinitions = (
   classNames: ClassNames,
-  exportType: ExportType
+  exportType: ExportType,
+  quoteType: QuoteType = "single"
 ): string | null => {
   if (classNames.length) {
     let typeDefinitions;
@@ -42,7 +51,11 @@ export const classNamesToTypeDefinitions = (
     switch (exportType) {
       case "default":
         typeDefinitions = "export interface Styles {\n";
-        typeDefinitions += classNames.map(classNameToInterfaceKey).join("\n");
+        typeDefinitions += classNames
+          .map((className: ClassName) => {
+            return classNameToInterfaceKey(className, quoteType);
+          })
+          .join("\n");
         typeDefinitions += "\n}\n\n";
         typeDefinitions += "export type ClassNames = keyof Styles;\n\n";
         typeDefinitions += "declare const styles: Styles;\n\n";

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -52,9 +52,7 @@ export const classNamesToTypeDefinitions = (
       case "default":
         typeDefinitions = "export interface Styles {\n";
         typeDefinitions += classNames
-          .map((className: ClassName) => {
-            return classNameToInterfaceKey(className, quoteType);
-          })
+          .map(className => classNameToInterfaceKey(className, quoteType))
           .join("\n");
         typeDefinitions += "\n}\n\n";
         typeDefinitions += "export type ClassNames = keyof Styles;\n\n";

--- a/lib/typescript/index.ts
+++ b/lib/typescript/index.ts
@@ -1,6 +1,8 @@
 export {
   classNamesToTypeDefinitions,
   ExportType,
-  EXPORT_TYPES
+  QuoteType,
+  EXPORT_TYPES,
+  QUOTE_TYPES
 } from "./class-names-to-type-definition";
 export { getTypeDefinitionPath } from "./get-type-definition-path";


### PR DESCRIPTION
I'm not sure if this would be useful to anybody else, but I wanted to be able to specify whether to use single or double quotes in the type definitions. Typically my tslint.json is set up for double quotes, so I have a bunch of TS errors showing from each of these files.