### PR TITLE
feat(quotetype): allow quoteType to be "none"

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ export interface IStyles {
 
 ### `--quoteType` (`-q`)
 
-- **Type**: `"single" | "double"`
+- **Type**: `"single" | "double" | "none"`
 - **Default**: `"single"`
 - **Example**: `tsm src --exportType default --quoteType double`
 

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -97,6 +97,35 @@ describe("classNamesToTypeDefinitions", () => {
       );
     });
 
+    it("uses no quotes for default exports when specified", () => {
+      const definition = classNamesToTypeDefinitions({
+        classNames: ["myClass", "yourClass"],
+        exportType: "default",
+        quoteType: "none"
+      });
+
+      expect(definition).toEqual(
+        "export interface Styles {\n  myClass: string;\n  yourClass: string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
+      );
+    });
+
+    it("prints a warning if a classname is invalid and does not include it in the type definitions", () => {
+      const definition = classNamesToTypeDefinitions({
+        classNames: ["myClass", "yourClass", "invalid-variable"],
+        exportType: "default",
+        quoteType: "none"
+      });
+
+      expect(definition).toEqual(
+        "export interface Styles {\n  myClass: string;\n  yourClass: string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
+      );
+      expect(console.log).toBeCalledWith(
+        expect.stringContaining(
+          `[SKIPPING] 'invalid-variable' contains dashes but --quoteType is none (consider using 'camel' for --nameFormat or choosing an other --quoteType).`
+        )
+      );
+    });
+
     it("does not affect named exports", () => {
       const definition = classNamesToTypeDefinitions({
         classNames: ["myClass", "yourClass"],


### PR DESCRIPTION
Hello,

I discovered this nice library a few hours ago and I am using prettier in some projects, and it does not enjoy - and I like it that way - putting useless quotes around keys.

```typsecript
export interface Styles {
  "thoseQuotesAroundMeAreUseless": string;
}
```

Perhaps in the future, the best way to enable anyone to remove those quotes would be to provide an option `noUselessQuotes`?

In the meanwhile, I propose this first PR where I implemented it an other way:
- by allowing the option `quoteType` to be `none`.

Also, I made it throw a warning if a classname contains a dash because obviously this would not compile, and the warning invites the user to pick other options.