### PR TITLE
fix(export-default): export a type instead of an interface Fixes #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ yarn tsm src
 
 For all possible commands, run `tsm --help`.
 
-The only required argument is the directoy where all SCSS files are located. Running `tsm src` will search for all files matching `src/**/*.scss`. This can be overridden by providing a [glob](https://github.com/isaacs/node-glob#glob-primer) pattern instead of a directory. For example, `tsm src/*.scss`
+The only required argument is the directory where all SCSS files are located. Running `tsm src` will search for all files matching `src/**/*.scss`. This can be overridden by providing a [glob](https://github.com/isaacs/node-glob#glob-primer) pattern instead of a directory. For example, `tsm src/*.scss`
 
 ### `--watch` (`-w`)
 
@@ -180,10 +180,10 @@ Given the following SCSS:
 The following type definitions will be generated:
 
 ```typescript
-export interface Styles {
+export type Styles = {
   text: string;
   textHighlighted: string;
-}
+};
 
 export type ClassNames = keyof Styles;
 
@@ -217,9 +217,9 @@ Customize the interface name exported in the generated file when `--exportType` 
 Only default exports are affected by this command. This example will change the export interface line to:
 
 ```typescript
-export interface IStyles {
+export type IStyles = {
   // ...
-}
+};
 ```
 
 ### `--quoteType` (`-q`)

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -59,7 +59,7 @@ describe("classNamesToTypeDefinitions", () => {
       });
 
       expect(definition).toEqual(
-        "export interface Styles {\n  'myClass': string;\n  'yourClass': string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
+        "export type Styles = {\n  'myClass': string;\n  'yourClass': string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
       );
     });
 
@@ -93,7 +93,7 @@ describe("classNamesToTypeDefinitions", () => {
       });
 
       expect(definition).toEqual(
-        'export interface Styles {\n  "myClass": string;\n  "yourClass": string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n'
+        'export type Styles = {\n  "myClass": string;\n  "yourClass": string;\n}\n\nexport type ClassNames = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n'
       );
     });
 
@@ -110,7 +110,7 @@ describe("classNamesToTypeDefinitions", () => {
     });
   });
 
-  describe("exportType name and interface options", () => {
+  describe("exportType name and type attributes", () => {
     it("uses custom value for ClassNames type name", () => {
       const definition = classNamesToTypeDefinitions({
         classNames: ["myClass", "yourClass"],
@@ -119,11 +119,11 @@ describe("classNamesToTypeDefinitions", () => {
       });
 
       expect(definition).toEqual(
-        "export interface Styles {\n  'myClass': string;\n  'yourClass': string;\n}\n\nexport type Classes = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
+        "export type Styles = {\n  'myClass': string;\n  'yourClass': string;\n}\n\nexport type Classes = keyof Styles;\n\ndeclare const styles: Styles;\n\nexport default styles;\n"
       );
     });
 
-    it("uses custom value for Styles interface name", () => {
+    it("uses custom value for Styles type name", () => {
       const definition = classNamesToTypeDefinitions({
         classNames: ["myClass", "yourClass"],
         exportType: "default",
@@ -131,7 +131,7 @@ describe("classNamesToTypeDefinitions", () => {
       });
 
       expect(definition).toEqual(
-        "export interface IStyles {\n  'myClass': string;\n  'yourClass': string;\n}\n\nexport type ClassNames = keyof IStyles;\n\ndeclare const styles: IStyles;\n\nexport default styles;\n"
+        "export type IStyles = {\n  'myClass': string;\n  'yourClass': string;\n}\n\nexport type ClassNames = keyof IStyles;\n\ndeclare const styles: IStyles;\n\nexport default styles;\n"
       );
     });
   });

--- a/examples/default-export/README.md
+++ b/examples/default-export/README.md
@@ -2,7 +2,7 @@
 
 This example contains:
 
-- Class names that are expected to be kebab (param) cased. Since variables cannot contain a `-` this can be achieved using an interface with default export.
+- Class names that are expected to be kebab (param) cased. Since variables cannot contain a `-` this can be achieved using a type with default export.
 - Class names that are TypeScript keywords (eg: `while`) that cannot be used as named constants.
 
 The command to generate the proper type files would look like this (_in the root of this repository_):

--- a/examples/default-export/feature-a/style.scss.d.ts
+++ b/examples/default-export/feature-a/style.scss.d.ts
@@ -1,8 +1,8 @@
-export interface Styles {
+export type Styles = {
   i: string;
   "i-am-kebab-cased": string;
   while: string;
-}
+};
 
 export type ClassNames = keyof Styles;
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -20,14 +20,14 @@ const { _: patterns, ...rest } = yargs
   .usage(
     "Generate .scss.d.ts from CSS module .scss files.\nUsage: $0 <glob pattern> [options]"
   )
-  .example("$0 src", "All .scss files at any level in the src directoy")
+  .example("$0 src", "All .scss files at any level in the src directory")
   .example(
     "$0 src/**/*.scss",
-    "All .scss files at any level in the src directoy"
+    "All .scss files at any level in the src directory"
   )
   .example(
     "$0 src/**/*.scss --watch",
-    "Watch all .scss files at any level in the src directoy that are added or changed"
+    "Watch all .scss files at any level in the src directory that are added or changed"
   )
   .example(
     "$0 src/**/*.scss --includePaths src/core src/variables",

--- a/lib/core/list-different.ts
+++ b/lib/core/list-different.ts
@@ -13,7 +13,7 @@ export const listDifferent = async (
   pattern: string,
   options: MainOptions
 ): Promise<void> => {
-  // Find all the files that match the provied pattern.
+  // Find all the files that match the provided pattern.
   const files = glob.sync(pattern);
 
   if (!files || !files.length) {

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -25,10 +25,7 @@ export const quoteTypeDefault: QuoteType = "single";
 const classNameToNamedTypeDefinition = (className: ClassName) =>
   `export const ${className}: string;`;
 
-const classNameToInterfaceKey = (
-  className: ClassName,
-  quoteType: QuoteType
-) => {
+const classNameToType = (className: ClassName, quoteType: QuoteType) => {
   const quote = quoteType === "single" ? "'" : '"';
   return `  ${quote}${className}${quote}: string;`;
 };
@@ -66,13 +63,10 @@ export const classNamesToTypeDefinitions = (
 
     switch (options.exportType) {
       case "default":
-        typeDefinitions = `export interface ${Styles} {\n`;
+        typeDefinitions = `export type ${Styles} = {\n`;
         typeDefinitions += options.classNames
           .map(className =>
-            classNameToInterfaceKey(
-              className,
-              options.quoteType || quoteTypeDefault
-            )
+            classNameToType(className, options.quoteType || quoteTypeDefault)
           )
           .join("\n");
         typeDefinitions += "\n}\n\n";
@@ -85,7 +79,7 @@ export const classNamesToTypeDefinitions = (
           .filter(isValidName)
           .map(classNameToNamedTypeDefinition);
 
-        // Sepearte all type definitions be a newline with a trailing newline.
+        // Separate all type definitions be a newline with a trailing newline.
         return typeDefinitions.join("\n") + "\n";
       default:
         return null;

--- a/lib/typescript/get-type-definition-path.ts
+++ b/lib/typescript/get-type-definition-path.ts
@@ -1,5 +1,5 @@
 /**
- * Given a file path to a SCSS file, generate the corresponding type defintion
+ * Given a file path to a SCSS file, generate the corresponding type definition
  * file path.
  *
  * @param file the SCSS file path


### PR DESCRIPTION
Rel: https://github.com/skovy/typed-scss-modules/issues/71

Before we were unable to do this:
```typescript
export interface Styles {
  'classname--first': string;
  'classname--second': string;
}

function foo(bar: Record<string, string>){
	return Object.keys(bar);
}
```

Because an interface does not allow being cast as a wider type. This fixes that by using types instead of interfaces:
```typescript
export type Styles = {
  'classname--first': string;
  'classname--second': string;
}
```

BREAKING CHANGE: this can interfere with how others use their default exported classnames

PS: added some typo fixes in as well
