### PR TITLE
feat(sortclassnames): implement sortClassNames option

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,14 @@ Print only some messages
 
 Print nothing
 
+### `--sortClassNames` (`-s`)
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **Example**: `tsm src --sortClassNames`
+
+Sort classNames alphabetically.
+
 ## Examples
 
 For examples, see the `examples` directory:

--- a/__tests__/sass/file-to-class-names.test.ts
+++ b/__tests__/sass/file-to-class-names.test.ts
@@ -101,4 +101,15 @@ describeAllImplementations(implementation => {
       });
     });
   });
+
+  describe("sortClassNames option", () => {
+    test("it sorts the results given a sort option", async () => {
+      const result = await fileToClassNames(`${__dirname}/../complex.scss`, {
+        implementation,
+        sortClassNames: true
+      });
+
+      expect(result).toEqual(["nestedAnother", "nestedClass", "someStyles"]);
+    });
+  });
 });

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -140,6 +140,12 @@ const { _: patterns, ...rest } = yargs
     default: logLevelDefault,
     alias: "L",
     describe: "Verbosity level of console output"
+  })
+  .option("sortClassNames", {
+    boolean: true,
+    default: false,
+    alias: "s",
+    describe: "Sort classNames alphabetically"
   }).argv;
 
 main(patterns[0], { ...rest });

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -19,6 +19,7 @@ export interface Options {
   aliasPrefixes?: Aliases;
   nameFormat?: NameFormat;
   implementation: Implementations;
+  sortClassNames?: boolean;
 }
 
 export const NAME_FORMATS: NameFormat[] = [
@@ -59,7 +60,8 @@ export const fileToClassNames = (
     aliases = {},
     aliasPrefixes = {},
     nameFormat = "camel",
-    implementation
+    implementation,
+    sortClassNames = false
   }: Options = {} as Options
 ) => {
   const transformer = classNameTransformer(nameFormat);
@@ -76,6 +78,10 @@ export const fileToClassNames = (
       sourceToClassNames(result.css).then(({ exportTokens }) => {
         const classNames = Object.keys(exportTokens);
         const transformedClassNames = classNames.map(transformer);
+
+        if (sortClassNames) {
+          transformedClassNames.sort((a, b) => a.localeCompare(b));
+        }
 
         resolve(transformedClassNames);
       });


### PR DESCRIPTION
## Rationale

- Coming from [TeamSupercell/typings-for-css-modules-loader](https://github.com/TeamSupercell/typings-for-css-modules-loader) it would be nice to get consistent output with that tool
- Order of things shouldn't need to affect output of types, and could lead to smaller future diffs when used

## Implementation

- Used [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare), could possibly get away with just calling `sort()`
- Added a test
- Added (a nugget of) documentation
- Used the key `sortClassNames`, which is a bit cumbersome but very clear, could maybe be just `sort`?
- Added `-s` as an alias for that (not sure if there is any strategy for choosing aliases)