### PR TITLE
feat: sort class names

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -34,7 +34,7 @@ describeAllImplementations(implementation => {
 
       expect(fs.writeFileSync).toBeCalledWith(
         `${expectedDirname}/complex.scss.d.ts`,
-        "export const someStyles: string;\nexport const nestedClass: string;\nexport const nestedAnother: string;\n"
+        "export const nestedAnother: string;\nexport const nestedClass: string;\nexport const someStyles: string;\n"
       );
       expect(fs.writeFileSync).toBeCalledWith(
         `${expectedDirname}/style.scss.d.ts`,
@@ -63,7 +63,7 @@ describeAllImplementations(implementation => {
       const expectedDirname = slash(__dirname);
       expect(fs.writeFileSync).toBeCalledWith(
         `${expectedDirname}/complex.scss.d.ts`,
-        "export const someStyles: string;\nexport const nestedClass: string;\nexport const nestedAnother: string;\n"
+        "export const nestedAnother: string;\nexport const nestedClass: string;\nexport const someStyles: string;\n"
       );
 
       // Files that should match the ignore pattern.

--- a/__tests__/sass/file-to-class-names.test.ts
+++ b/__tests__/sass/file-to-class-names.test.ts
@@ -7,7 +7,7 @@ describeAllImplementations(implementation => {
     test("it converts a file path to an array of class names (default camel cased)", async () => {
       const result = await fileToClassNames(`${__dirname}/../complex.scss`);
 
-      expect(result).toEqual(["someStyles", "nestedClass", "nestedAnother"]);
+      expect(result).toEqual(["nestedAnother", "nestedClass", "someStyles"]);
     });
 
     describe("nameFormat", () => {
@@ -18,9 +18,9 @@ describeAllImplementations(implementation => {
         });
 
         expect(result).toEqual([
-          "some-styles",
+          "nested-another",
           "nested-class",
-          "nested-another"
+          "some-styles"
         ]);
       });
 
@@ -31,9 +31,9 @@ describeAllImplementations(implementation => {
         });
 
         expect(result).toEqual([
-          "some-styles",
+          "nested-another",
           "nested-class",
-          "nested-another"
+          "some-styles"
         ]);
       });
 
@@ -43,7 +43,7 @@ describeAllImplementations(implementation => {
           implementation
         });
 
-        expect(result).toEqual(["App", "Logo", "appHeader"]);
+        expect(result).toEqual(["App", "appHeader", "Logo"]);
       });
 
       test("it does not change class names when nameFormat is set to none", async () => {
@@ -52,7 +52,7 @@ describeAllImplementations(implementation => {
           implementation
         });
 
-        expect(result).toEqual(["App", "Logo", "App-Header"]);
+        expect(result).toEqual(["App", "App-Header", "Logo"]);
       });
     });
 
@@ -67,11 +67,11 @@ describeAllImplementations(implementation => {
         });
 
         expect(result).toEqual([
-          "someStyles",
-          "nestedClass",
+          "myCustomClass",
           "nestedAnother",
+          "nestedClass",
           "someClass",
-          "myCustomClass"
+          "someStyles"
         ]);
       });
     });
@@ -92,11 +92,11 @@ describeAllImplementations(implementation => {
         );
 
         expect(result).toEqual([
-          "someStyles",
-          "nestedClass",
+          "myCustomClass",
           "nestedAnother",
+          "nestedClass",
           "nestedStyles",
-          "myCustomClass"
+          "someStyles"
         ]);
       });
     });

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -75,7 +75,9 @@ export const fileToClassNames = (
 
       sourceToClassNames(result.css).then(({ exportTokens }) => {
         const classNames = Object.keys(exportTokens);
-        const transformedClassNames = classNames.map(transformer);
+        const transformedClassNames = classNames
+          .map(transformer)
+          .sort((a, b) => a.localeCompare(b));
 
         resolve(transformedClassNames);
       });


### PR DESCRIPTION
Implements sort class names change as a forced default as opposed to optionally like in #79 

I'm a bit unsure what the `scss.d.ts` files in the test folder are for and if I should change those?

BREAKING: This changes the current behavior and scss.d.ts files should probably be regenerated.