### PR TITLE
feat: use prettier to format files before save if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ export type IStyles = {
 - **Default**: `"single"`
 - **Example**: `tsm src --exportType default --quoteType double`
 
-Specify a quote type to match your TypeScript configuration. Only default exports are affected by this command. This example will wrap class names with double quotes (").
+Specify a quote type to match your TypeScript configuration. Only default exports are affected by this command. This example will wrap class names with double quotes ("). If prettier is installed and configured in the project, it will be used and is likely to override the effect of this setting.
 
 ### `--logLevel` (`-L`)
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ export type IStyles = {
 - **Default**: `"single"`
 - **Example**: `tsm src --exportType default --quoteType double`
 
-Specify a quote type to match your TypeScript configuration. Only default exports are affected by this command. This example will wrap class names with double quotes ("). If prettier is installed and configured in the project, it will be used and is likely to override the effect of this setting.
+Specify a quote type to match your TypeScript configuration. Only default exports are affected by this command. This example will wrap class names with double quotes ("). If [Prettier](https://prettier.io) is installed and configured in the project, it will be used and is likely to override the effect of this setting.
 
 ### `--logLevel` (`-L`)
 

--- a/__tests__/core/__snapshots__/attemptPrettier.test.ts.snap
+++ b/__tests__/core/__snapshots__/attemptPrettier.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`attemptPrettier should match snapshot 1`] = `
+"export type Styles = {
+  nestedAnother: string;
+  nestedClass: string;
+  someStyles: string;
+};
+
+export type ClassNames = keyof Styles;
+
+declare const styles: Styles;
+
+export default styles;
+"
+`;

--- a/__tests__/core/attemptPrettier.test.ts
+++ b/__tests__/core/attemptPrettier.test.ts
@@ -1,5 +1,4 @@
 import { attemptPrettier } from "../../lib/core/attemptPrettier";
-import { fileToClassNames } from "../../lib/sass";
 import { classNamesToTypeDefinitions } from "../../lib/typescript";
 
 import prettier from "prettier";
@@ -14,9 +13,8 @@ describe("attemptPrettier", () => {
   });
 
   it("should match snapshot", async () => {
-    const classNames = await fileToClassNames(`${__dirname}/../complex.scss`);
     const typeDefinition = classNamesToTypeDefinitions({
-      classNames,
+      classNames: ["nestedAnother", "nestedClass", "someStyles"],
       exportType: "default"
     });
 

--- a/__tests__/core/attemptPrettier.test.ts
+++ b/__tests__/core/attemptPrettier.test.ts
@@ -1,0 +1,54 @@
+import { attemptPrettier } from "../../lib/core/attemptPrettier";
+import { fileToClassNames } from "../../lib/sass";
+import { classNamesToTypeDefinitions } from "../../lib/typescript";
+
+import prettier from "prettier";
+
+const input =
+  "export type Styles = {'myClass': string;'yourClass': string;}; export type Classes = keyof Styles; declare const styles: Styles; export default styles;";
+
+describe("attemptPrettier", () => {
+  it("should locate and apply prettier.format", async () => {
+    const output = await attemptPrettier(input);
+    expect(prettier.format(input, { parser: "typescript" })).toMatch(output);
+  });
+
+  it("should match snapshot", async () => {
+    const classNames = await fileToClassNames(`${__dirname}/../complex.scss`);
+    const typeDefinition = classNamesToTypeDefinitions({
+      classNames,
+      exportType: "default"
+    });
+
+    if (!typeDefinition) {
+      throw new Error("failed to collect typeDefinition");
+    }
+
+    const output = await attemptPrettier(typeDefinition);
+    expect(output).toMatchSnapshot();
+  });
+});
+
+describe("attemptPrettier - mock prettier", () => {
+  beforeAll(() => {
+    jest.mock("prettier", () => ({
+      format: undefined
+    }));
+  });
+
+  it("should fail to recognize prettier and return input", async () => {
+    const output = await attemptPrettier(input);
+    expect(input).toMatch(output);
+  });
+});
+
+describe("attemptPrettier - mock canResolvePrettier", () => {
+  beforeAll(() => {
+    jest.mock("../../lib/core/canResolvePrettier");
+  });
+
+  it("should fail to resolve prettier and return input", async () => {
+    const output = await attemptPrettier(input);
+    expect(input).toMatch(output);
+  });
+});

--- a/lib/core/attemptPrettier.ts
+++ b/lib/core/attemptPrettier.ts
@@ -1,0 +1,52 @@
+import { alerts } from "./alerts";
+import { canResolvePrettier } from "./canResolvePrettier";
+
+import { format, resolveConfig } from "prettier";
+
+interface Prettier {
+  format: typeof format;
+  resolveConfig: typeof resolveConfig;
+}
+
+const isPrettier = (t: unknown): t is Prettier =>
+  t &&
+  typeof t === "object" &&
+  t !== null &&
+  "format" in t &&
+  typeof (t as Prettier).format === "function" &&
+  "resolveConfig" in t &&
+  typeof (t as Prettier).resolveConfig === "function";
+
+/**
+ * Try to load prettier and config from project to format input,
+ * fall back to input if prettier is not found or failed
+ *
+ * @param {string} input
+ */
+export const attemptPrettier = async (input: string) => {
+  if (!canResolvePrettier()) {
+    return input;
+  }
+
+  const prettier = require("prettier");
+  if (!isPrettier(prettier)) {
+    // doesn't look like prettier
+    return input;
+  }
+
+  try {
+    const config = await prettier.resolveConfig(process.cwd(), {
+      editorconfig: true
+    });
+    // try to return formatted output
+    return prettier.format(
+      input,
+      Object.assign({}, config, { parser: "typescript" })
+    );
+  } catch (error) {
+    alerts.notice(`Tried using prettier, but failed with error: ${error}`);
+  }
+
+  // failed to format
+  return input;
+};

--- a/lib/core/attemptPrettier.ts
+++ b/lib/core/attemptPrettier.ts
@@ -39,10 +39,7 @@ export const attemptPrettier = async (input: string) => {
       editorconfig: true
     });
     // try to return formatted output
-    return prettier.format(
-      input,
-      Object.assign({}, config, { parser: "typescript" })
-    );
+    return prettier.format(input, { ...config, parser: "typescript" });
   } catch (error) {
     alerts.notice(`Tried using prettier, but failed with error: ${error}`);
   }

--- a/lib/core/canResolvePrettier.ts
+++ b/lib/core/canResolvePrettier.ts
@@ -1,0 +1,11 @@
+// this is only extracted to a module to mock in testing as require.resolve can't be mocked.
+// https://github.com/facebook/jest/issues/9543
+export function canResolvePrettier() {
+  try {
+    require.resolve("prettier");
+    return true;
+  } catch (_error) {
+    // cannot resolve prettier
+    return false;
+  }
+}

--- a/lib/core/write-file.ts
+++ b/lib/core/write-file.ts
@@ -8,6 +8,7 @@ import {
 } from "../typescript";
 import { fileToClassNames } from "../sass";
 import { MainOptions } from "./types";
+import { attemptPrettier } from "./attemptPrettier";
 
 /**
  * Given a single file generate the proper types.
@@ -33,8 +34,10 @@ export const writeFile = (
 
       const path = getTypeDefinitionPath(file);
 
-      fs.writeFileSync(path, typeDefinition);
-      alerts.success(`[GENERATED TYPES] ${path}`);
+      return attemptPrettier(typeDefinition).then(output => {
+        fs.writeFileSync(path, output);
+        alerts.success(`[GENERATED TYPES] ${path}`);
+      });
     })
     .catch(({ message, file, line, column }: SassError) => {
       const location = file ? `(${file}[${line}:${column}])` : "";

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/jest": "^24.0.0",
     "@types/node-sass": "^3.10.32",
     "@types/param-case": "^1.1.2",
+    "@types/prettier": "^2.1.0",
     "@types/reserved-words": "^0.1.0",
     "@types/sass": "^1.16.0",
     "@types/yargs": "^12.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,6 +527,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/prettier@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.0.tgz#5f96562c1075ee715a5b138f0b7f591c1f40f6b8"
+  integrity sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==
+
 "@types/reserved-words@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@types/reserved-words/-/reserved-words-0.1.0.tgz#a9d5318bb4ac4466862b93fc702542b75d2cd3ac"


### PR DESCRIPTION
I wanted to take a stab at #69 because I was curious how to solve config loading, turns out prettier has a function for that, [resolveConfig](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options), which made this pretty easy to add. I spent more time on the tests than I care to admit, because I couldn't figure out why `require.resolve` couldn't be mocked, found a workaround when moving that to a module. I don't think calling the promise like I do in `writeFile` is very nice (nested promises), so I started to convert to async / await, but decided that would be too much of a change here, and reverted. Also, this behavior should probably be documented somehow, but unsure where to add that and how to describe it. It could also be an option, but I would bet that those who has installed prettier in their project would like to use it. 

Imports from prettier are only used as types, so prettier does not get included. 
 