### PR TITLE
feat(banner): allows user to append banner / comment to the top of every output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,21 @@ Print only some messages
 
 Print nothing
 
+### `--banner`
+
+- **Type**: `string`
+- **Default**: `undefined`
+- **Example**: `tsm src --banner '// This is an example banner\n'`
+
+Will prepend a string to the top of your output files
+
+```typescript
+// This is an example banner
+export type Styles = {
+  // ...
+};
+```
+
 ## Examples
 
 For examples, see the `examples` directory:

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -10,14 +10,14 @@ describe.only("cli", () => {
   describe("examples", () => {
     it("should run the basic example without errors", () => {
       const result = execSync(
-        `yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables`
+        `yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables --banner '// example banner\n'`
       ).toString();
 
       expect(result).toContain("Found 3 files. Generating type definitions...");
     });
     it("should run the default-export example without errors", () => {
       const result = execSync(
-        `yarn tsm "examples/default-export/**/*.scss" --exportType default --nameFormat kebab`
+        `yarn tsm "examples/default-export/**/*.scss" --exportType default --nameFormat kebab --banner '// example banner\n'`
       ).toString();
 
       expect(result).toContain("Found 1 file. Generating type definitions...");

--- a/__tests__/core/attemptPrettier.test.ts
+++ b/__tests__/core/attemptPrettier.test.ts
@@ -14,6 +14,7 @@ describe("attemptPrettier", () => {
 
   it("should match snapshot", async () => {
     const typeDefinition = classNamesToTypeDefinitions({
+      banner: "",
       classNames: ["nestedAnother", "nestedClass", "someStyles"],
       exportType: "default"
     });

--- a/__tests__/core/generate.test.ts
+++ b/__tests__/core/generate.test.ts
@@ -15,6 +15,7 @@ describeAllImplementations(implementation => {
       const pattern = `${__dirname}/../**/*.scss`;
 
       await generate(pattern, {
+        banner: "",
         watch: false,
         ignoreInitial: false,
         exportType: "named",

--- a/__tests__/core/list-different.test.ts
+++ b/__tests__/core/list-different.test.ts
@@ -19,6 +19,7 @@ describeAllImplementations(implementation => {
       const pattern = `${__dirname}/../**/*.scss`;
 
       await listDifferent(pattern, {
+        banner: "",
         watch: false,
         ignoreInitial: false,
         exportType: "named",
@@ -51,6 +52,7 @@ describeAllImplementations(implementation => {
       const pattern = `${__dirname}/../**/style.scss`;
 
       await listDifferent(pattern, {
+        banner: "",
         watch: false,
         ignoreInitial: false,
         exportType: "named",

--- a/__tests__/core/write-file.test.ts
+++ b/__tests__/core/write-file.test.ts
@@ -18,6 +18,7 @@ describeAllImplementations(implementation => {
       const typesFile = getTypeDefinitionPath(testFile);
 
       await writeFile(testFile, {
+        banner: "",
         watch: false,
         ignoreInitial: false,
         exportType: "named",
@@ -44,6 +45,7 @@ describeAllImplementations(implementation => {
       const testFile = `${__dirname}/../empty.scss`;
 
       await writeFile(testFile, {
+        banner: "",
         watch: false,
         ignoreInitial: false,
         exportType: "named",

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -16,6 +16,7 @@ describeAllImplementations(implementation => {
       const pattern = `${__dirname}`;
 
       await main(pattern, {
+        banner: "",
         watch: false,
         ignoreInitial: false,
         exportType: "named",
@@ -46,6 +47,7 @@ describeAllImplementations(implementation => {
       const pattern = `${__dirname}`;
 
       await main(pattern, {
+        banner: "",
         watch: false,
         ignoreInitial: false,
         exportType: "named",

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -135,4 +135,16 @@ describe("classNamesToTypeDefinitions", () => {
       );
     });
   });
+
+  describe("Banner support", () => {
+    it("appends the banner to the top of the output file", () => {
+      const banner = "// Example banner";
+      const definition = classNamesToTypeDefinitions({
+        banner,
+        classNames: ["myClass", "yourClass"],
+        exportType: "default"
+      });
+      expect(definition).toContain(banner);
+    });
+  });
 });

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -8,6 +8,7 @@ describe("classNamesToTypeDefinitions", () => {
   describe("named", () => {
     it("converts an array of class name strings to type definitions", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass", "yourClass"],
         exportType: "named"
       });
@@ -19,6 +20,7 @@ describe("classNamesToTypeDefinitions", () => {
 
     it("returns null if there are no class names", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: [],
         exportType: "named"
       });
@@ -28,6 +30,7 @@ describe("classNamesToTypeDefinitions", () => {
 
     it("prints a warning if a classname is a reserved keyword and does not include it in the type definitions", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass", "if"],
         exportType: "named"
       });
@@ -40,6 +43,7 @@ describe("classNamesToTypeDefinitions", () => {
 
     it("prints a warning if a classname is invalid and does not include it in the type definitions", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass", "invalid-variable"],
         exportType: "named"
       });
@@ -54,6 +58,7 @@ describe("classNamesToTypeDefinitions", () => {
   describe("default", () => {
     it("converts an array of class name strings to type definitions", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass", "yourClass"],
         exportType: "default"
       });
@@ -65,6 +70,7 @@ describe("classNamesToTypeDefinitions", () => {
 
     it("returns null if there are no class names", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: [],
         exportType: "default"
       });
@@ -76,6 +82,7 @@ describe("classNamesToTypeDefinitions", () => {
   describe("invalid export type", () => {
     it("returns null", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass"],
         exportType: "invalid" as ExportType
       });
@@ -87,6 +94,7 @@ describe("classNamesToTypeDefinitions", () => {
   describe("quoteType", () => {
     it("uses double quotes for default exports when specified", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass", "yourClass"],
         exportType: "default",
         quoteType: "double"
@@ -99,6 +107,7 @@ describe("classNamesToTypeDefinitions", () => {
 
     it("does not affect named exports", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass", "yourClass"],
         exportType: "named",
         quoteType: "double"
@@ -113,6 +122,7 @@ describe("classNamesToTypeDefinitions", () => {
   describe("exportType name and type attributes", () => {
     it("uses custom value for ClassNames type name", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass", "yourClass"],
         exportType: "default",
         exportTypeName: "Classes"
@@ -125,6 +135,7 @@ describe("classNamesToTypeDefinitions", () => {
 
     it("uses custom value for Styles type name", () => {
       const definition = classNamesToTypeDefinitions({
+        banner: "",
         classNames: ["myClass", "yourClass"],
         exportType: "default",
         exportTypeInterface: "IStyles"
@@ -137,12 +148,22 @@ describe("classNamesToTypeDefinitions", () => {
   });
 
   describe("Banner support", () => {
-    it("appends the banner to the top of the output file", () => {
+    it("appends the banner to the top of the output file: default", () => {
       const banner = "// Example banner";
       const definition = classNamesToTypeDefinitions({
         banner,
         classNames: ["myClass", "yourClass"],
         exportType: "default"
+      });
+      expect(definition).toContain(banner);
+    });
+
+    it("appends the banner to the top of the output file: named", () => {
+      const banner = "// Example banner";
+      const definition = classNamesToTypeDefinitions({
+        banner,
+        classNames: ["myClass", "yourClass"],
+        exportType: "named"
       });
       expect(definition).toContain(banner);
     });

--- a/examples/basic/feature-a/style.scss.d.ts
+++ b/examples/basic/feature-a/style.scss.d.ts
@@ -1,2 +1,3 @@
+// example banner
 export const text: string;
 export const textHighlighted: string;

--- a/examples/basic/feature-a/style.scss.d.ts
+++ b/examples/basic/feature-a/style.scss.d.ts
@@ -1,3 +1,4 @@
 // example banner
+
 export const text: string;
 export const textHighlighted: string;

--- a/examples/basic/feature-b/style.scss.d.ts
+++ b/examples/basic/feature-b/style.scss.d.ts
@@ -1,2 +1,3 @@
 // example banner
+
 export const topBanner: string;

--- a/examples/basic/feature-b/style.scss.d.ts
+++ b/examples/basic/feature-b/style.scss.d.ts
@@ -1,1 +1,2 @@
+// example banner
 export const topBanner: string;

--- a/examples/default-export/feature-a/style.scss.d.ts
+++ b/examples/default-export/feature-a/style.scss.d.ts
@@ -1,3 +1,4 @@
+// example banner
 export type Styles = {
   i: string;
   "i-am-kebab-cased": string;

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -4,6 +4,7 @@ import yargs from "yargs";
 
 import { nameFormatDefault, Aliases, NAME_FORMATS } from "./sass";
 import {
+  bannerTypeDefault,
   exportTypeDefault,
   exportTypeInterfaceDefault,
   exportTypeNameDefault,
@@ -140,6 +141,12 @@ const { _: patterns, ...rest } = yargs
     default: logLevelDefault,
     alias: "L",
     describe: "Verbosity level of console output"
+  })
+  .options("banner", {
+    string: true,
+    default: bannerTypeDefault,
+    describe:
+      "Inserts text at the top of every output file for documentation purposes."
   }).argv;
 
 main(patterns[0], { ...rest });

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -2,7 +2,7 @@ import { Options } from "../sass";
 import { ExportType, QuoteType, LogLevel } from "../typescript";
 
 export interface MainOptions extends Options {
-  banner?: string;
+  banner: string;
   ignore: string[];
   ignoreInitial: boolean;
   exportType: ExportType;

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -2,6 +2,7 @@ import { Options } from "../sass";
 import { ExportType, QuoteType, LogLevel } from "../typescript";
 
 export interface MainOptions extends Options {
+  banner?: string;
   ignore: string[];
   ignoreInitial: boolean;
   exportType: ExportType;

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -10,7 +10,7 @@ export type QuoteType = "single" | "double";
 export const QUOTE_TYPES: QuoteType[] = ["single", "double"];
 
 export interface TypeDefinitionOptions {
-  banner?: string;
+  banner: string;
   classNames: ClassNames;
   exportType: ExportType;
   exportTypeName?: string;
@@ -22,6 +22,7 @@ export const exportTypeDefault: ExportType = "named";
 export const exportTypeNameDefault: string = "ClassNames";
 export const exportTypeInterfaceDefault: string = "Styles";
 export const quoteTypeDefault: QuoteType = "single";
+export const bannerTypeDefault: string = "";
 
 const classNameToNamedTypeDefinition = (className: ClassName) =>
   `export const ${className}: string;`;

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -10,6 +10,7 @@ export type QuoteType = "single" | "double";
 export const QUOTE_TYPES: QuoteType[] = ["single", "double"];
 
 export interface TypeDefinitionOptions {
+  banner?: string;
   classNames: ClassNames;
   exportType: ExportType;
   exportTypeName?: string;
@@ -63,7 +64,8 @@ export const classNamesToTypeDefinitions = (
 
     switch (options.exportType) {
       case "default":
-        typeDefinitions = `export type ${Styles} = {\n`;
+        typeDefinitions = options.banner || "";
+        typeDefinitions += `export type ${Styles} = {\n`;
         typeDefinitions += options.classNames
           .map(className =>
             classNameToType(className, options.quoteType || quoteTypeDefault)
@@ -78,6 +80,10 @@ export const classNamesToTypeDefinitions = (
         typeDefinitions = options.classNames
           .filter(isValidName)
           .map(classNameToNamedTypeDefinition);
+
+        if (options.banner) {
+          typeDefinitions.unshift(options.banner);
+        }
 
         // Separate all type definitions be a newline with a trailing newline.
         return typeDefinitions.join("\n") + "\n";

--- a/lib/typescript/index.ts
+++ b/lib/typescript/index.ts
@@ -1,4 +1,5 @@
 export {
+  bannerTypeDefault,
   classNamesToTypeDefinitions,
   exportTypeDefault,
   exportTypeInterfaceDefault,


### PR DESCRIPTION
Inspired by the [banner option in similar typings-for-css-modules-loader](https://github.com/Jimdo/typings-for-css-modules-loader#banner-option), this allows users to prepend any string to the top of their output files for the sake of documentation.

Example usage:

```
tsm src --banner '// This is a generated file.\n// Please do not edit this file.\n'
```

would result in files with output:

```typescript
// This is a generated file.
// Please do not edit this file.
export type Styles = {
...
```