### PR TITLE
Feat/remove d ts files

### DIFF
--- a/__tests__/core/remove-file.test.ts
+++ b/__tests__/core/remove-file.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 
 import { alerts } from "../../lib/core/alerts";
-import { removeFile } from "../../lib/core/remove-file";
+import { removeSCSSTypeDefinitionFile } from "../../lib/core/remove-file";
 import { getTypeDefinitionPath } from "../../lib/typescript";
 
 jest.mock("fs");
@@ -25,7 +25,7 @@ describe("removeFile", () => {
     const existsSyncSpy = fs.existsSync;
     const unlinkSyncSpy = fs.unlinkSync;
     const existingTypes = getTypeDefinitionPath(existingFile);
-    removeFile(existingFile);
+    removeSCSSTypeDefinitionFile(existingFile);
     expect(existsSyncSpy).toBeCalledWith(expect.stringMatching(existingFile));
     expect(existsSyncSpy).not.toBeCalledWith(
       expect.stringMatching(existingTypes)
@@ -38,7 +38,7 @@ describe("removeFile", () => {
     const unlinkSyncSpy = fs.unlinkSync;
     const nonExistingFile = `${__dirname}/../deleted.scss`;
     const nonExistingTypes = getTypeDefinitionPath(nonExistingFile);
-    removeFile(nonExistingFile);
+    removeSCSSTypeDefinitionFile(nonExistingFile);
     expect(existsSyncSpy).toBeCalledWith(
       expect.stringMatching(nonExistingFile)
     );
@@ -51,7 +51,7 @@ describe("removeFile", () => {
   it("removes *.scss.d.ts types file for *.scss", () => {
     const existsSyncSpy = fs.existsSync;
     const unlinkSyncSpy = fs.unlinkSync;
-    removeFile(originalTestFile);
+    removeSCSSTypeDefinitionFile(originalTestFile);
     expect(existsSyncSpy).toBeCalledWith(expect.stringMatching(existingTypes));
     expect(unlinkSyncSpy).toBeCalled();
     expect(unlinkSyncSpy).toBeCalledWith(expect.stringMatching(existingTypes));

--- a/__tests__/core/remove-file.test.ts
+++ b/__tests__/core/remove-file.test.ts
@@ -1,0 +1,60 @@
+import fs from "fs";
+
+import { alerts } from "../../lib/core/alerts";
+import { removeFile } from "../../lib/core/remove-file";
+import { getTypeDefinitionPath } from "../../lib/typescript";
+
+jest.mock("fs");
+jest.mock("../../lib/core/alerts");
+
+describe("removeFile", () => {
+  const originalTestFile = `${__dirname}/../removable.scss`;
+  const existingFile = `${__dirname}/../style.scss`;
+  const existingTypes = getTypeDefinitionPath(originalTestFile);
+
+  beforeEach(() => {
+    (fs.existsSync as jest.Mock).mockImplementation(
+      (path: fs.PathLike): boolean =>
+        path === existingTypes || path === existingFile
+    );
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it("does nothing if *.scss file style exists", async () => {
+    const existsSyncSpy = fs.existsSync;
+    const unlinkSyncSpy = fs.unlinkSync;
+    const existingTypes = getTypeDefinitionPath(existingFile);
+    removeFile(existingFile);
+    expect(existsSyncSpy).toBeCalledWith(expect.stringMatching(existingFile));
+    expect(existsSyncSpy).not.toBeCalledWith(
+      expect.stringMatching(existingTypes)
+    );
+    expect(unlinkSyncSpy).not.toBeCalled();
+    expect(alerts.success).not.toBeCalled();
+  });
+  it("does nothing if types file doesn't exist", async () => {
+    const existsSyncSpy = fs.existsSync;
+    const unlinkSyncSpy = fs.unlinkSync;
+    const nonExistingFile = `${__dirname}/../deleted.scss`;
+    const nonExistingTypes = getTypeDefinitionPath(nonExistingFile);
+    removeFile(nonExistingFile);
+    expect(existsSyncSpy).toBeCalledWith(
+      expect.stringMatching(nonExistingFile)
+    );
+    expect(existsSyncSpy).toBeCalledWith(
+      expect.stringMatching(nonExistingTypes)
+    );
+    expect(unlinkSyncSpy).not.toBeCalled();
+    expect(alerts.success).not.toBeCalled();
+  });
+  it("removes *.scss.d.ts types file for *.scss", () => {
+    const existsSyncSpy = fs.existsSync;
+    const unlinkSyncSpy = fs.unlinkSync;
+    removeFile(originalTestFile);
+    expect(existsSyncSpy).toBeCalledWith(expect.stringMatching(existingTypes));
+    expect(unlinkSyncSpy).toBeCalled();
+    expect(unlinkSyncSpy).toBeCalledWith(expect.stringMatching(existingTypes));
+    expect(alerts.success).toBeCalled();
+  });
+});

--- a/__tests__/core/remove-file.test.ts
+++ b/__tests__/core/remove-file.test.ts
@@ -21,18 +21,6 @@ describe("removeFile", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  it("does nothing if *.scss file style exists", async () => {
-    const existsSyncSpy = fs.existsSync;
-    const unlinkSyncSpy = fs.unlinkSync;
-    const existingTypes = getTypeDefinitionPath(existingFile);
-    removeSCSSTypeDefinitionFile(existingFile);
-    expect(existsSyncSpy).toBeCalledWith(expect.stringMatching(existingFile));
-    expect(existsSyncSpy).not.toBeCalledWith(
-      expect.stringMatching(existingTypes)
-    );
-    expect(unlinkSyncSpy).not.toBeCalled();
-    expect(alerts.success).not.toBeCalled();
-  });
   it("does nothing if types file doesn't exist", async () => {
     const existsSyncSpy = fs.existsSync;
     const unlinkSyncSpy = fs.unlinkSync;

--- a/lib/core/remove-file.ts
+++ b/lib/core/remove-file.ts
@@ -13,7 +13,7 @@ const removeFile = (file: string): void => {
   try {
     if (fs.existsSync(file)) {
       fs.unlinkSync(file);
-      alerts.success(`[REMOVED TYPES] ${file}`);
+      alerts.success(`[REMOVED] ${file}`);
     }
   } catch (error) {
     alerts.error(

--- a/lib/core/remove-file.ts
+++ b/lib/core/remove-file.ts
@@ -4,23 +4,33 @@ import { alerts } from "./alerts";
 import { getTypeDefinitionPath } from "../typescript";
 
 /**
- * Given a single file remove the generated types if they exist
+ * Given a single file remove the file
  *
- * @param file the SCSS file to generate types for
+ * @param file any file to remove
  */
-export const removeFile = (file: string): void => {
-  if (fs.existsSync(file)) {
-    return;
-  }
-  const path = getTypeDefinitionPath(file);
+
+const removeFile = (file: string): void => {
   try {
-    if (fs.existsSync(path)) {
-      fs.unlinkSync(path);
-      alerts.success(`[REMOVED TYPES] ${path}`);
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file);
+      alerts.success(`[REMOVED TYPES] ${file}`);
     }
   } catch (error) {
     alerts.error(
       `An error occurred removing ${file}:\n${JSON.stringify(error)}`
     );
   }
+};
+
+/**
+ * Given a single file remove the generated types if they exist
+ *
+ * @param file the SCSS file to generate types for
+ */
+export const removeSCSSTypeDefinitionFile = (file: string): void => {
+  if (fs.existsSync(file)) {
+    return;
+  }
+  const path = getTypeDefinitionPath(file);
+  removeFile(path);
 };

--- a/lib/core/remove-file.ts
+++ b/lib/core/remove-file.ts
@@ -1,0 +1,26 @@
+import fs from "fs";
+
+import { alerts } from "./alerts";
+import { getTypeDefinitionPath } from "../typescript";
+
+/**
+ * Given a single file remove the generated types if they exist
+ *
+ * @param file the SCSS file to generate types for
+ */
+export const removeFile = (file: string): void => {
+  if (fs.existsSync(file)) {
+    return;
+  }
+  const path = getTypeDefinitionPath(file);
+  try {
+    if (fs.existsSync(path)) {
+      fs.unlinkSync(path);
+      alerts.success(`[REMOVED TYPES] ${path}`);
+    }
+  } catch (error) {
+    alerts.error(
+      `An error occurred removing ${file}:\n${JSON.stringify(error)}`
+    );
+  }
+};

--- a/lib/core/remove-file.ts
+++ b/lib/core/remove-file.ts
@@ -28,9 +28,6 @@ const removeFile = (file: string): void => {
  * @param file the SCSS file to generate types for
  */
 export const removeSCSSTypeDefinitionFile = (file: string): void => {
-  if (fs.existsSync(file)) {
-    return;
-  }
   const path = getTypeDefinitionPath(file);
   removeFile(path);
 };

--- a/lib/core/watch.ts
+++ b/lib/core/watch.ts
@@ -1,6 +1,7 @@
 import chokidar from "chokidar";
 
 import { alerts } from "./alerts";
+import { removeFile } from "./remove-file";
 import { writeFile } from "./write-file";
 import { MainOptions } from "./types";
 
@@ -25,5 +26,9 @@ export const watch = (pattern: string, options: MainOptions): void => {
     .on("add", (path) => {
       alerts.info(`[ADDED] ${path}`);
       writeFile(path, options);
+    })
+    .on("unlink", (path) => {
+      alerts.info(`[REMOVED] ${path}`);
+      removeFile(path);
     });
 };

--- a/lib/core/watch.ts
+++ b/lib/core/watch.ts
@@ -1,7 +1,7 @@
 import chokidar from "chokidar";
 
 import { alerts } from "./alerts";
-import { removeFile } from "./remove-file";
+import { removeSCSSTypeDefinitionFile } from "./remove-file";
 import { writeFile } from "./write-file";
 import { MainOptions } from "./types";
 
@@ -29,6 +29,6 @@ export const watch = (pattern: string, options: MainOptions): void => {
     })
     .on("unlink", (path) => {
       alerts.info(`[REMOVED] ${path}`);
-      removeFile(path);
+      removeSCSSTypeDefinitionFile(path);
     });
 };


### PR DESCRIPTION
### Description
This PR attempts to address https://github.com/skovy/typed-scss-modules/issues/61. It looks to add the ability to delete old `.d.ts` files that do not have `.scss` files anymore


The PR high level attempts to add the ability to delete files while using the `--watch` flag.
