### PR TITLE
feat: add update option to prevent unnecessary file updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,16 @@ export type IStyles = {
 
 Specify a quote type to match your TypeScript configuration. Only default exports are affected by this command. This example will wrap class names with double quotes ("). If [Prettier](https://prettier.io) is installed and configured in the project, it will be used and is likely to override the effect of this setting.
 
+### `--updateStaleOnly` (`-u`)
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **Example**: `tsm src --updateStaleOnly`
+
+Overwrite generated files only if the source file has more recent changes. This can be useful if you want to avoid extraneous file updates, which can cause watcher processes to trigger unnecessarily (e.g. `tsc --watch`).
+
+Caveat: If a generated type definition file is updated manually, it won't be re-generated until the corresponding scss file is also updated.
+
 ### `--logLevel` (`-L`)
 
 - **Type**: `"verbose" | "error" | "info" | "silent"`

--- a/__tests__/core/generate.test.ts
+++ b/__tests__/core/generate.test.ts
@@ -25,6 +25,7 @@ describeAllImplementations((implementation) => {
         ignore: [],
         implementation,
         quoteType: "single",
+        updateStaleOnly: false,
         logLevel: "verbose",
       });
 

--- a/__tests__/core/list-different.test.ts
+++ b/__tests__/core/list-different.test.ts
@@ -3,7 +3,7 @@ import { listDifferent } from "../../lib/core";
 import { describeAllImplementations } from "../helpers";
 
 describeAllImplementations((implementation) => {
-  describe("writeFile", () => {
+  describe("listDifferent", () => {
     let exit: jest.SpyInstance;
 
     beforeEach(() => {
@@ -36,6 +36,7 @@ describeAllImplementations((implementation) => {
         ignore: [],
         implementation,
         quoteType: "single",
+        updateStaleOnly: false,
         logLevel: "verbose",
       });
 
@@ -62,6 +63,7 @@ describeAllImplementations((implementation) => {
         ignore: [],
         implementation,
         quoteType: "single",
+        updateStaleOnly: false,
         logLevel: "verbose",
         nameFormat: "kebab",
       });
@@ -84,6 +86,7 @@ describeAllImplementations((implementation) => {
         ignore: [],
         implementation,
         quoteType: "single",
+        updateStaleOnly: false,
         logLevel: "verbose",
       });
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -27,6 +27,7 @@ describeAllImplementations((implementation) => {
         ignore: [],
         implementation,
         quoteType: "single",
+        updateStaleOnly: false,
         logLevel: "verbose",
       });
 
@@ -58,6 +59,7 @@ describeAllImplementations((implementation) => {
         ignore: ["**/style.scss"],
         implementation,
         quoteType: "single",
+        updateStaleOnly: false,
         logLevel: "verbose",
       });
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -135,6 +135,13 @@ const { _: patterns, ...rest } = yargs
     describe:
       "Specify the quote type so that generated files adhere to your TypeScript rules.",
   })
+  .options("updateStaleOnly", {
+    boolean: true,
+    default: false,
+    alias: "u",
+    describe:
+      "Overwrite generated files only if the source file has more recent changes.",
+  })
   .option("logLevel", {
     string: true,
     choices: LOG_LEVELS,

--- a/lib/core/list-different.ts
+++ b/lib/core/list-different.ts
@@ -48,7 +48,7 @@ export const checkFile = (
 
       const path = getTypeDefinitionPath(file);
 
-      const content = fs.readFileSync(path, { encoding: "UTF8" });
+      const content = fs.readFileSync(path, { encoding: "utf8" });
 
       if (content === typeDefinition) {
         resolve(true);

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -10,6 +10,7 @@ export interface MainOptions extends Options {
   exportTypeInterface: string;
   listDifferent: boolean;
   quoteType: QuoteType;
+  updateStaleOnly: boolean;
   watch: boolean;
   logLevel: LogLevel;
 }

--- a/lib/core/write-file.ts
+++ b/lib/core/write-file.ts
@@ -32,6 +32,16 @@ export const writeFile = (
       }
 
       const path = getTypeDefinitionPath(file);
+
+      if (options.updateStaleOnly) {
+        const fileModified = fs.statSync(file).mtime;
+        const typeDefinitionModified = fs.statSync(path).mtime;
+
+        if (fileModified < typeDefinitionModified) {
+          return;
+        }
+      }
+
       fs.writeFileSync(path, typeDefinition);
       alerts.success(`[GENERATED TYPES] ${path}`);
     })


### PR DESCRIPTION
This change was inspired by the `--update` option from [cpx](https://github.com/mysticatea/cpx). Without this option, `tsm` was overwriting type definition files in my project, causing TypeScript recompilations. In a large project, this can cause some significant performance problems.

I purposefully didn't update the README or add test coverage yet because I'd like feedback on the general approach first. I'm happy to add these changes after collecting initial thoughts! Does this idea have the potential to make it into a release? Thanks!