### PR TITLE
Support "Composing from other files" css module feature.

### DIFF
--- a/__tests__/core/generate.test.ts
+++ b/__tests__/core/generate.test.ts
@@ -29,7 +29,7 @@ describeAllImplementations((implementation) => {
         logLevel: "verbose",
       });
 
-      expect(fs.writeFileSync).toBeCalledTimes(5);
+      expect(fs.writeFileSync).toBeCalledTimes(6);
     });
   });
 });

--- a/__tests__/dummy-styles/composes.scss
+++ b/__tests__/dummy-styles/composes.scss
@@ -1,0 +1,4 @@
+.composed-class {
+  composes: nested-styles from "./nested-styles/style.scss";
+  color: red;
+}

--- a/__tests__/dummy-styles/composes.scss.d.ts
+++ b/__tests__/dummy-styles/composes.scss.d.ts
@@ -1,0 +1,1 @@
+export const composedClass: string;

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -31,7 +31,7 @@ describeAllImplementations((implementation) => {
         logLevel: "verbose",
       });
 
-      expect(fs.writeFileSync).toBeCalledTimes(5);
+      expect(fs.writeFileSync).toBeCalledTimes(6);
 
       const expectedDirname = slash(path.join(__dirname, "dummy-styles"));
 
@@ -63,7 +63,7 @@ describeAllImplementations((implementation) => {
         logLevel: "verbose",
       });
 
-      expect(fs.writeFileSync).toBeCalledTimes(3);
+      expect(fs.writeFileSync).toBeCalledTimes(4);
 
       const expectedDirname = slash(path.join(__dirname, "dummy-styles"));
 

--- a/__tests__/sass/file-to-class-names.test.ts
+++ b/__tests__/sass/file-to-class-names.test.ts
@@ -117,5 +117,18 @@ describeAllImplementations((implementation) => {
         ]);
       });
     });
+
+    describe("composes", () => {
+      test("it converts a file that contains a composes dependency from another file", async () => {
+        const result = await fileToClassNames(
+          `${__dirname}/../dummy-styles/composes.scss`,
+          {
+            implementation,
+          }
+        );
+
+        expect(result).toEqual(["composedClass"]);
+      });
+    });
   });
 });

--- a/lib/sass/source-to-class-names.ts
+++ b/lib/sass/source-to-class-names.ts
@@ -6,4 +6,4 @@ export const sourceToClassNames = (source: Source) => {
   return core.load(source, undefined, undefined, noOpPathFetcher);
 };
 
-const noOpPathFetcher = () => Promise.resolve([]);
+const noOpPathFetcher = () => Promise.resolve({});

--- a/lib/sass/source-to-class-names.ts
+++ b/lib/sass/source-to-class-names.ts
@@ -3,5 +3,7 @@ import Core, { Source } from "css-modules-loader-core";
 const core = new Core();
 
 export const sourceToClassNames = (source: Source) => {
-  return core.load(source);
+  return core.load(source, undefined, undefined, noOpPathFetcher);
 };
+
+const noOpPathFetcher = () => Promise.resolve([]);


### PR DESCRIPTION
Fixes the issue described in https://github.com/skovy/typed-scss-modules/issues/57

This PR adds support for generating definition files for an scss module like this:
```
.composed-class {
  composes: nested-styles from "./nested-styles/style.scss";
  color: red;
}
```

Support is achieved by passing a dummy `PathFetcher` to css-module-loader-core.

A dummy implementation is sufficient as the composition does not add new class names to the module.

css-module-loader-core directly passes the returned object to icss-replace-symbols as the `replacements` map. That library will simply skip replacing a symbol when the key is not present in the `replacements` map: https://github.com/css-modules/icss-utils/blob/master/src/replaceValueSymbols.js#L7-L17