### PR TITLE
Fix banner formatting

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 
-describe.only("cli", () => {
+describe("cli", () => {
   it("should run when no files are found", () => {
     const result = execSync("yarn tsm src").toString();
 
@@ -10,14 +10,15 @@ describe.only("cli", () => {
   describe("examples", () => {
     it("should run the basic example without errors", () => {
       const result = execSync(
-        `yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables --banner '// example banner\n'`
+        `yarn tsm "examples/basic/**/*.scss" --includePaths examples/basic/core --aliases.~alias variables --banner '// example banner'`
       ).toString();
 
       expect(result).toContain("Found 3 files. Generating type definitions...");
     });
+
     it("should run the default-export example without errors", () => {
       const result = execSync(
-        `yarn tsm "examples/default-export/**/*.scss" --exportType default --nameFormat kebab --banner '// example banner\n'`
+        `yarn tsm "examples/default-export/**/*.scss" --exportType default --nameFormat kebab --banner '// example banner'`
       ).toString();
 
       expect(result).toContain("Found 1 file. Generating type definitions...");

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { classNamesToTypeDefinitions, ExportType } from "../../lib/typescript";
 
 jest.mock("../../lib/prettier/can-resolve", () => ({
@@ -152,6 +153,8 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
   });
 
   describe("Banner support", () => {
+    const firstLine = (str: string): string => str.split(os.EOL)[0];
+
     it("appends the banner to the top of the output file: default", async () => {
       const banner = "// Example banner";
       const definition = await classNamesToTypeDefinitions({
@@ -159,7 +162,7 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
         classNames: ["myClass", "yourClass"],
         exportType: "default",
       });
-      expect(definition).toContain(banner);
+      expect(firstLine(definition!)).toBe(banner);
     });
 
     it("appends the banner to the top of the output file: named", async () => {
@@ -169,7 +172,7 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
         classNames: ["myClass", "yourClass"],
         exportType: "named",
       });
-      expect(definition).toContain(banner);
+      expect(firstLine(definition!)).toBe(banner);
     });
   });
 });

--- a/examples/basic/feature-a/style.scss.d.ts
+++ b/examples/basic/feature-a/style.scss.d.ts
@@ -1,4 +1,3 @@
 // example banner
-
 export const text: string;
 export const textHighlighted: string;

--- a/examples/basic/feature-b/style.scss.d.ts
+++ b/examples/basic/feature-b/style.scss.d.ts
@@ -1,3 +1,2 @@
 // example banner
-
 export const topBanner: string;


### PR DESCRIPTION
Fixes https://github.com/skovy/typed-scss-modules/issues/117

Additionally, this PR updates both cases to push each line into an array, and then join using newlines. Longer-term might be nice to use babel and construct a proper AST and avoid the manual string construction, but hopefully, now both are handled consistently these types of issues due to the difference in logic will be easier to avoid (and not overlook).