### PR TITLE
Fix missing type file using --listDifferent option

### DIFF
--- a/__tests__/core/list-different.test.ts
+++ b/__tests__/core/list-different.test.ts
@@ -93,5 +93,34 @@ describeAllImplementations((implementation) => {
       expect(exit).not.toHaveBeenCalled();
       expect(console.log).not.toHaveBeenCalled();
     });
+
+    test("logs not generated type file and exits with 1", async () => {
+      const pattern = `${__dirname}/list-different/no-generated.scss`;
+
+      await listDifferent(pattern, {
+        banner: "",
+        watch: false,
+        ignoreInitial: false,
+        exportType: "named",
+        exportTypeName: "ClassNames",
+        exportTypeInterface: "Styles",
+        listDifferent: true,
+        ignore: [],
+        implementation,
+        quoteType: "single",
+        updateStaleOnly: false,
+        logLevel: "verbose",
+      });
+
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(console.log).toBeCalledWith(
+        expect.stringContaining(
+          `[INVALID TYPES] Type file needs to be generated for`
+        )
+      );
+      expect(console.log).toBeCalledWith(
+        expect.stringContaining(`no-generated.scss`)
+      );
+    });
   });
 });

--- a/__tests__/core/list-different/no-generated.scss
+++ b/__tests__/core/list-different/no-generated.scss
@@ -1,0 +1,3 @@
+.no-generated {
+  color: blue;
+}

--- a/lib/core/list-different.ts
+++ b/lib/core/list-different.ts
@@ -58,12 +58,13 @@ export const checkFile = (
 
       const content = fs.readFileSync(path, { encoding: "utf8" });
 
-      if (content === typeDefinition) {
-        resolve(true);
-      } else {
+      if (content !== typeDefinition) {
         alerts.error(`[INVALID TYPES] Check type definitions for ${file}`);
         resolve(false);
+        return;
       }
+
+      resolve(true);
     })
   );
 };

--- a/lib/core/list-different.ts
+++ b/lib/core/list-different.ts
@@ -48,6 +48,14 @@ export const checkFile = (
 
       const path = getTypeDefinitionPath(file);
 
+      if (!fs.existsSync(path)) {
+        alerts.error(
+          `[INVALID TYPES] Type file needs to be generated for ${file} `
+        );
+        resolve(false);
+        return;
+      }
+
       const content = fs.readFileSync(path, { encoding: "utf8" });
 
       if (content === typeDefinition) {


### PR DESCRIPTION
When running `tsm` with option `--listDifferent`, and all type definition files are not yet generated, code raises an error that is not catch.
Even if type definition file does not exist, script exits with 0.

This PR fixes this issue by checkig previously if the file exists. If not, it raises an error.