### PR TITLE
feat: export main as tsm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 dist
+.DS_Store

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,1 @@
+export { main as default } from "./main";

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "typed-scss-modules",
   "version": "0.0.0",
   "description": "TypeScript type definition generator for SCSS CSS Modules",
-  "main": "index.js",
+  "main": "dist/lib/index.js",
+  "types": "dist/lib/index.d.ts",
   "author": "Spencer Miskoviak <smiskoviak@gmail.com>",
   "license": "MIT",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "declaration": true,
     "outDir": "./dist",
     "rootDirs": [".", "examples/output-folder/__generated__"]
   }


### PR DESCRIPTION
It would be really useful to be able to programmatically invoke `tsm` as opposed to running it via a CLI command.

People can currently do this in a hacky way by importing the `main` function from `typed-scss-modules/dist/lib/main.js`.

This PR adds a real entry point and adds the exporting of type declarations.

Example usage: `import tsm from 'typed-scss-modules';`