### PR TITLE
fix: alias and aliasPrefixes in config file

### DIFF
--- a/__tests__/load.test.ts
+++ b/__tests__/load.test.ts
@@ -179,4 +179,68 @@ describe("#mergeOptions", () => {
       importer,
     });
   });
+
+  it("should give ignore undefined CLI options", () => {
+    const importer = jest.fn();
+
+    expect(
+      mergeOptions(
+        {
+          aliases: undefined,
+          aliasPrefixes: undefined,
+          nameFormat: "kebab",
+          implementation: "sass",
+          exportType: "default",
+          exportTypeName: "Classes",
+          exportTypeInterface: "AllStyles",
+          watch: true,
+          ignoreInitial: true,
+          listDifferent: true,
+          ignore: ["path"],
+          quoteType: "double",
+          updateStaleOnly: true,
+          logLevel: "silent",
+          banner: undefined,
+          outputFolder: "__cli-generated__",
+        },
+        {
+          aliases: {},
+          aliasPrefixes: {},
+          nameFormat: "param",
+          implementation: "node-sass",
+          exportType: "named",
+          exportTypeName: "Classnames",
+          exportTypeInterface: "TheStyles",
+          watch: false,
+          ignoreInitial: false,
+          listDifferent: false,
+          ignore: ["another/path"],
+          quoteType: "single",
+          updateStaleOnly: false,
+          logLevel: "info",
+          banner: "// banner",
+          outputFolder: "__generated__",
+          importer,
+        }
+      )
+    ).toEqual({
+      aliases: {},
+      aliasPrefixes: {},
+      nameFormat: "kebab",
+      implementation: "sass",
+      exportType: "default",
+      exportTypeName: "Classes",
+      exportTypeInterface: "AllStyles",
+      watch: true,
+      ignoreInitial: true,
+      listDifferent: true,
+      ignore: ["path"],
+      quoteType: "double",
+      updateStaleOnly: true,
+      logLevel: "silent",
+      banner: "// banner",
+      outputFolder: "__cli-generated__",
+      importer,
+    });
+  });
 });

--- a/examples/config-file/typed-scss-modules.config.js
+++ b/examples/config-file/typed-scss-modules.config.js
@@ -1,6 +1,8 @@
 const jsonImporter = require("node-sass-json-importer");
 
 export const config = {
+  aliases: { "not-real": "test-value" },
+  aliasPrefixes: { "also-not-real": "test-value" },
   banner: "// config file banner",
   nameFormat: "kebab",
   exportType: "default",

--- a/lib/load.ts
+++ b/lib/load.ts
@@ -77,6 +77,16 @@ export const DEFAULT_OPTIONS: CLIOptions = {
   outputFolder: null,
 };
 
+const removedUndefinedValues = <Obj extends {}>(obj: Obj): Obj => {
+  for (let key in obj) {
+    if (obj[key] === undefined) {
+      delete obj[key];
+    }
+  }
+
+  return obj;
+};
+
 /**
  * Given both the CLI and config file options merge into a single options object.
  *
@@ -92,6 +102,6 @@ export const mergeOptions = (
   return {
     ...DEFAULT_OPTIONS,
     ...configOptions,
-    ...cliOptions,
+    ...removedUndefinedValues(cliOptions),
   };
 };


### PR DESCRIPTION
Resolves https://github.com/skovy/typed-scss-modules/issues/157

For some reason using `coerce` with `yargs` will always set a value, even `undefined`. I removed `coerce` but there is no other clean way to cast to the correct type. Instead, it was much easier to simply remove `undefined` values from the CLI options and make this more future proof as well.