### PR TITLE
Adds support for multiple name formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,15 @@ This matches the common use-case for importing scss files from node_modules when
 
 ### `--nameFormat` (`-n`)
 
-- **Type**: `"camel" | "kebab" | "param" | "snake" | "dashes" | "none"`
+- **Type**: `"all" | "camel" | "kebab" | "param" | "snake" | "dashes" | "none"`
 - **Default**: `"camel"`
-- **Example**: `typed-scss-modules src --nameFormat camel`
+- **Examples**:
+  - `typed-scss-modules src --nameFormat camel`
+  - `typed-scss-modules src --nameFormat kebab --nameFormat dashes --exportType default`. In order to use multiple formatters, you must use `--exportType default`.
 
 The class naming format to use when converting the classes to type definitions.
 
+- **all**: makes use of all formatters (except `all` and `none`) and converts all class names to their respective formats, with no duplication. In order to use this option, you must use `--exportType default`.
 - **camel**: convert all class names to camel-case, e.g. `App-Logo` => `appLogo`.
 - **kebab**/**param**: convert all class names to kebab/param case, e.g. `App-Logo` => `app-logo` (all lower case with '-' separators).
 - **dashes**: only convert class names containing dashes to camel-case, leave others alone, e.g. `App` => `App`, `App-Logo` => `appLogo`. Matches the webpack [css-loader camelCase 'dashesOnly'](https://github.com/webpack-contrib/css-loader#camelcase) option.

--- a/__tests__/core/list-different.test.ts
+++ b/__tests__/core/list-different.test.ts
@@ -66,7 +66,7 @@ describeAllImplementations((implementation) => {
         quoteType: "single",
         updateStaleOnly: false,
         logLevel: "verbose",
-        nameFormat: "kebab",
+        nameFormat: ["kebab"],
         outputFolder: null,
       });
 

--- a/__tests__/load.test.ts
+++ b/__tests__/load.test.ts
@@ -44,7 +44,7 @@ describe("#mergeOptions", () => {
     expect(
       mergeOptions(
         {
-          nameFormat: "kebab",
+          nameFormat: ["kebab"],
           implementation: "sass",
           exportType: "default",
           exportTypeName: "Classes",
@@ -62,7 +62,7 @@ describe("#mergeOptions", () => {
         {}
       )
     ).toEqual({
-      nameFormat: "kebab",
+      nameFormat: ["kebab"],
       implementation: "sass",
       exportType: "default",
       exportTypeName: "Classes",
@@ -86,7 +86,7 @@ describe("#mergeOptions", () => {
       mergeOptions(
         {},
         {
-          nameFormat: "kebab",
+          nameFormat: ["kebab"],
           implementation: "sass",
           exportType: "default",
           exportTypeName: "Classes",
@@ -104,7 +104,7 @@ describe("#mergeOptions", () => {
         }
       )
     ).toEqual({
-      nameFormat: "kebab",
+      nameFormat: ["kebab"],
       implementation: "sass",
       exportType: "default",
       exportTypeName: "Classes",
@@ -128,7 +128,7 @@ describe("#mergeOptions", () => {
     expect(
       mergeOptions(
         {
-          nameFormat: "kebab",
+          nameFormat: ["kebab"],
           implementation: "sass",
           exportType: "default",
           exportTypeName: "Classes",
@@ -144,7 +144,7 @@ describe("#mergeOptions", () => {
           outputFolder: "__cli-generated__",
         },
         {
-          nameFormat: "param",
+          nameFormat: ["param"],
           implementation: "node-sass",
           exportType: "named",
           exportTypeName: "Classnames",
@@ -162,7 +162,7 @@ describe("#mergeOptions", () => {
         }
       )
     ).toEqual({
-      nameFormat: "kebab",
+      nameFormat: ["kebab"],
       implementation: "sass",
       exportType: "default",
       exportTypeName: "Classes",
@@ -188,7 +188,7 @@ describe("#mergeOptions", () => {
         {
           aliases: undefined,
           aliasPrefixes: undefined,
-          nameFormat: "kebab",
+          nameFormat: ["kebab"],
           implementation: "sass",
           exportType: "default",
           exportTypeName: "Classes",
@@ -206,7 +206,7 @@ describe("#mergeOptions", () => {
         {
           aliases: {},
           aliasPrefixes: {},
-          nameFormat: "param",
+          nameFormat: ["param"],
           implementation: "node-sass",
           exportType: "named",
           exportTypeName: "Classnames",
@@ -226,7 +226,7 @@ describe("#mergeOptions", () => {
     ).toEqual({
       aliases: {},
       aliasPrefixes: {},
-      nameFormat: "kebab",
+      nameFormat: ["kebab"],
       implementation: "sass",
       exportType: "default",
       exportTypeName: "Classes",

--- a/__tests__/sass/file-to-class-names.test.ts
+++ b/__tests__/sass/file-to-class-names.test.ts
@@ -84,6 +84,47 @@ describeAllImplementations((implementation) => {
 
         expect(result).toEqual(["App", "App-Header", "Logo"]);
       });
+
+      test("it applies all transformers when is set to all", async () => {
+        const result = await fileToClassNames(
+          `${__dirname}/../dummy-styles/complex.scss`,
+          {
+            nameFormat: "all",
+            implementation,
+          }
+        );
+
+        expect(result).toEqual([
+          "nested_another",
+          "nested_class",
+          "nested-another",
+          "nested-class",
+          "nestedAnother",
+          "nestedClass",
+          "some_styles",
+          "some-styles",
+          "someStyles",
+        ]);
+      });
+
+      test("it applies multiple transformers when sent as an array", async () => {
+        const result = await fileToClassNames(
+          `${__dirname}/../dummy-styles/complex.scss`,
+          {
+            nameFormat: ["kebab", "snake"],
+            implementation,
+          }
+        );
+
+        expect(result).toEqual([
+          "nested_another",
+          "nested_class",
+          "nested-another",
+          "nested-class",
+          "some_styles",
+          "some-styles",
+        ]);
+      });
     });
 
     describe("aliases", () => {

--- a/__tests__/sass/file-to-class-names.test.ts
+++ b/__tests__/sass/file-to-class-names.test.ts
@@ -17,7 +17,7 @@ describeAllImplementations((implementation) => {
         const result = await fileToClassNames(
           `${__dirname}/../dummy-styles/complex.scss`,
           {
-            nameFormat: "kebab",
+            nameFormat: ["kebab"],
             implementation,
           }
         );
@@ -33,7 +33,7 @@ describeAllImplementations((implementation) => {
         const result = await fileToClassNames(
           `${__dirname}/../dummy-styles/complex.scss`,
           {
-            nameFormat: "param",
+            nameFormat: ["param"],
             implementation,
           }
         );
@@ -49,7 +49,7 @@ describeAllImplementations((implementation) => {
         const result = await fileToClassNames(
           `${__dirname}/../dummy-styles/complex.scss`,
           {
-            nameFormat: "snake",
+            nameFormat: ["snake"],
             implementation,
           }
         );
@@ -65,7 +65,7 @@ describeAllImplementations((implementation) => {
         const result = await fileToClassNames(
           `${__dirname}/../dummy-styles/dashes.scss`,
           {
-            nameFormat: "dashes",
+            nameFormat: ["dashes"],
             implementation,
           }
         );
@@ -77,7 +77,7 @@ describeAllImplementations((implementation) => {
         const result = await fileToClassNames(
           `${__dirname}/../dummy-styles/dashes.scss`,
           {
-            nameFormat: "none",
+            nameFormat: ["none"],
             implementation,
           }
         );
@@ -89,7 +89,7 @@ describeAllImplementations((implementation) => {
         const result = await fileToClassNames(
           `${__dirname}/../dummy-styles/complex.scss`,
           {
-            nameFormat: "all",
+            nameFormat: ["all"],
             implementation,
           }
         );

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -2,10 +2,11 @@
 
 import yargs from "yargs";
 
-import { Aliases, NAME_FORMATS } from "./sass";
+import { Aliases, NameFormatInput, NAME_FORMATS } from "./sass";
 import { EXPORT_TYPES, QUOTE_TYPES, LOG_LEVELS } from "./typescript";
 import { main } from "./main";
 import { IMPLEMENTATIONS } from "./implementations";
+import { CLIOptions } from "./core";
 
 const { _: patterns, ...rest } = yargs
   .usage(
@@ -62,9 +63,12 @@ const { _: patterns, ...rest } = yargs
     describe: "A prefix for any import to rewrite to another value.",
   })
   .option("nameFormat", {
-    choices: NAME_FORMATS,
     alias: "n",
+    array: true,
+    choices: NAME_FORMATS,
+    coerce: (arr: NameFormatInput[] | undefined) => arr,
     describe: "The name format that should be used to transform class names.",
+    type: "array",
   })
   .option("implementation", {
     choices: IMPLEMENTATIONS,
@@ -143,4 +147,4 @@ const { _: patterns, ...rest } = yargs
   })
   .parseSync();
 
-main(patterns[0] as string, { ...rest });
+main(patterns[0] as string, { ...rest } as Partial<CLIOptions>);

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -2,11 +2,10 @@
 
 import yargs from "yargs";
 
-import { Aliases, NameFormatInput, NAME_FORMATS } from "./sass";
+import { Aliases, NAME_FORMATS } from "./sass";
 import { EXPORT_TYPES, QUOTE_TYPES, LOG_LEVELS } from "./typescript";
 import { main } from "./main";
 import { IMPLEMENTATIONS } from "./implementations";
-import { CLIOptions } from "./core";
 
 const { _: patterns, ...rest } = yargs
   .usage(
@@ -66,9 +65,7 @@ const { _: patterns, ...rest } = yargs
     alias: "n",
     array: true,
     choices: NAME_FORMATS,
-    coerce: (arr: NameFormatInput[] | undefined) => arr,
     describe: "The name format that should be used to transform class names.",
-    type: "array",
   })
   .option("implementation", {
     choices: IMPLEMENTATIONS,
@@ -147,4 +144,4 @@ const { _: patterns, ...rest } = yargs
   })
   .parseSync();
 
-main(patterns[0] as string, { ...rest } as Partial<CLIOptions>);
+main(patterns[0] as string, { ...rest });

--- a/lib/load.ts
+++ b/lib/load.ts
@@ -61,7 +61,7 @@ export const loadConfig = async (): Promise<{} | ConfigOptions> => {
 
 // Default values for all options that need defaults.
 export const DEFAULT_OPTIONS: CLIOptions = {
-  nameFormat: nameFormatDefault,
+  nameFormat: [nameFormatDefault],
   implementation: getDefaultImplementation(),
   exportType: exportTypeDefault,
   exportTypeName: exportTypeNameDefault,

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -10,29 +10,23 @@ interface Transformer {
   (className: ClassName): string;
 }
 
-export const NAME_FORMATS = [
-  "all",
-  "camel",
-  "dashes",
-  "kebab",
-  "none",
-  "param",
-  "snake",
-] as const;
+const transformersMap = {
+  camel: (className: string) => camelCase(className),
+  dashes: (className: string) =>
+    /-/.test(className) ? camelCase(className) : className,
+  kebab: (className: string) => transformersMap.param(className),
+  none: (className: string) => className,
+  param: (className: string) => paramCase(className),
+  snake: (className: string) => snakeCase(className),
+} as const;
 
-export type NameFormatInput = typeof NAME_FORMATS[number];
+export type NameFormatInput = keyof typeof transformersMap | "all" | "none";
+
+export const NAME_FORMATS = Object.keys(transformersMap).concat([
+  "all",
+]) as NameFormatInput[];
 
 type NameFormatsWithTransformer = Exclude<NameFormatInput, "all">;
-
-const transformersMap: Record<NameFormatsWithTransformer, Transformer> = {
-  camel: (className) => camelCase(className),
-  dashes: (className) =>
-    /-/.test(className) ? camelCase(className) : className,
-  kebab: (className) => transformersMap.param(className),
-  none: (className) => className,
-  param: (className) => paramCase(className),
-  snake: (className) => snakeCase(className),
-};
 
 export interface SASSOptions extends SASSImporterOptions {
   additionalData?: string;

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -61,7 +61,7 @@ export const fileToClassNames = (
   if (nameFormat) {
     nameFormats = (
       nameFormat.includes("all")
-        ? NAME_FORMATS.filter((item) => item !== "all")
+        ? NAME_FORMATS.filter((item) => item !== "all" && item !== "none")
         : nameFormat
     ) as NameFormatsWithTransformer[];
   }

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -22,11 +22,8 @@ const transformersMap = {
 } as const;
 
 type NameFormatsWithTransformer = keyof typeof transformersMap;
-type NameFormatInput = NameFormatsWithTransformer | "all";
 
-export const NAME_FORMATS = Object.keys(transformersMap).concat([
-  "all",
-]) as NameFormatInput[];
+export const NAME_FORMATS = Object.keys(transformersMap).concat(["all"]);
 
 export interface SASSOptions extends SASSImporterOptions {
   additionalData?: string;

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -21,21 +21,20 @@ const transformersMap = {
   snake: (className: ClassName) => snakeCase(className),
 } as const;
 
-export type NameFormatInput = keyof typeof transformersMap | "all" | "none";
+type NameFormatsWithTransformer = keyof typeof transformersMap;
+type NameFormatInput = NameFormatsWithTransformer | "all";
 
 export const NAME_FORMATS = Object.keys(transformersMap).concat([
   "all",
 ]) as NameFormatInput[];
 
-type NameFormatsWithTransformer = Exclude<NameFormatInput, "all">;
-
 export interface SASSOptions extends SASSImporterOptions {
   additionalData?: string;
   includePaths?: string[];
-  nameFormat?: NameFormatInput[];
+  nameFormat?: (string | number)[];
   implementation: Implementations;
 }
-export const nameFormatDefault: NameFormatInput = "camel";
+export const nameFormatDefault: NameFormatsWithTransformer = "camel";
 
 export const fileToClassNames = async (
   file: string,

--- a/lib/sass/index.ts
+++ b/lib/sass/index.ts
@@ -2,7 +2,6 @@ export {
   nameFormatDefault,
   fileToClassNames,
   Aliases,
-  NameFormatInput,
   SASSOptions,
   NAME_FORMATS,
 } from "./file-to-class-names";

--- a/lib/sass/index.ts
+++ b/lib/sass/index.ts
@@ -2,7 +2,7 @@ export {
   nameFormatDefault,
   fileToClassNames,
   Aliases,
-  NameFormat,
+  NameFormatInput,
   SASSOptions,
   NAME_FORMATS,
 } from "./file-to-class-names";

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -2,7 +2,7 @@ import os from "os";
 
 import reserved from "reserved-words";
 
-import { ClassNames, ClassName } from "lib/sass/file-to-class-names";
+import { ClassName } from "lib/sass/file-to-class-names";
 import { alerts } from "../core";
 import { attemptPrettier } from "../prettier";
 
@@ -14,7 +14,7 @@ export const QUOTE_TYPES: QuoteType[] = ["single", "double"];
 
 export interface TypeDefinitionOptions {
   banner: string;
-  classNames: ClassNames;
+  classNames: ClassName[];
   exportType: ExportType;
   exportTypeName?: string;
   exportTypeInterface?: string;


### PR DESCRIPTION
## What does this PR do

* Adds support for multiple name formatters, allowing a user to pass multiple `-n <formatName>` which will generate unique class names accordingly
* Adds support for the formatter's name `all` which includes all formatters, excluding `all` and `none`.
* Adds tests for the support of such feature.
* Refactors `lib/sass/file-to-class-names.ts` code to a more modern approach using `async ... await` and improves the types.