### PR TITLE
feat: perform sanity check in watch mode

### DIFF
--- a/__tests__/core/list-files-and-perform-sanity-check.test.ts
+++ b/__tests__/core/list-files-and-perform-sanity-check.test.ts
@@ -1,0 +1,44 @@
+import { ConfigOptions } from "../../lib/core";
+import { listFilesAndPerformSanityChecks } from "../../lib/core/list-files-and-perform-sanity-checks";
+
+const options: ConfigOptions = {
+  banner: "",
+  watch: false,
+  ignoreInitial: false,
+  exportType: "named",
+  exportTypeName: "ClassNames",
+  exportTypeInterface: "Styles",
+  listDifferent: true,
+  ignore: [],
+  implementation: "sass",
+  quoteType: "single",
+  updateStaleOnly: false,
+  logLevel: "verbose",
+  outputFolder: null,
+};
+
+describe("listAllFilesAndPerformSanityCheck", () => {
+  beforeEach(() => {
+    console.log = jest.fn();
+  });
+
+  it("prints a warning if the pattern matches 0 files", () => {
+    const pattern = `${__dirname}/list-different/test.txt`;
+
+    listFilesAndPerformSanityChecks(pattern, options);
+
+    expect(console.log).toBeCalledWith(
+      expect.stringContaining("No files found.")
+    );
+  });
+
+  it("prints a warning if the pattern matches 1 file", () => {
+    const pattern = `${__dirname}/list-different/formatted.scss`;
+
+    listFilesAndPerformSanityChecks(pattern, options);
+
+    expect(console.log).toBeCalledWith(
+      expect.stringContaining("Only 1 file found for")
+    );
+  });
+});

--- a/lib/core/generate.ts
+++ b/lib/core/generate.ts
@@ -1,6 +1,5 @@
-import glob from "glob";
-
 import { alerts } from "./alerts";
+import { listFilesAndPerformSanityChecks } from "./list-files-and-perform-sanity-checks";
 import { ConfigOptions } from "./types";
 import { writeFile } from "./write-file";
 
@@ -14,20 +13,10 @@ export const generate = async (
   pattern: string,
   options: ConfigOptions
 ): Promise<void> => {
-  // Find all the files that match the provided pattern.
-  const files = glob.sync(pattern, { ignore: options.ignore });
+  const files = listFilesAndPerformSanityChecks(pattern, options);
 
-  if (!files || !files.length) {
-    alerts.error("No files found.");
+  if (files.length === 0) {
     return;
-  }
-
-  // This case still works as expected but it's easy to do on accident so
-  // provide a (hopefully) helpful warning.
-  if (files.length === 1) {
-    alerts.warn(
-      `Only 1 file found for ${pattern}. If using a glob pattern (eg: dir/**/*.scss) make sure to wrap in quotes (eg: "dir/**/*.scss").`
-    );
   }
 
   alerts.success(

--- a/lib/core/list-files-and-perform-sanity-checks.ts
+++ b/lib/core/list-files-and-perform-sanity-checks.ts
@@ -1,0 +1,33 @@
+import glob from "glob";
+
+import { alerts } from "./alerts";
+import { ConfigOptions } from "./types";
+
+/**
+ * Return the files matching the given pattern and alert the user if only 0 or 1
+ * files matched.
+ *
+ * @param pattern the file pattern to generate type definitions for
+ * @param options the CLI options
+ */
+export function listFilesAndPerformSanityChecks(
+  pattern: string,
+  options: ConfigOptions
+): string[] {
+  // Find all the files that match the provided pattern.
+  const files = glob.sync(pattern, { ignore: options.ignore });
+
+  if (!files || !files.length) {
+    alerts.error("No files found.");
+  }
+
+  // This case still works as expected but it's easy to do on accident so
+  // provide a (hopefully) helpful warning.
+  if (files.length === 1) {
+    alerts.warn(
+      `Only 1 file found for ${pattern}. If using a glob pattern (eg: dir/**/*.scss) make sure to wrap in quotes (eg: "dir/**/*.scss").`
+    );
+  }
+
+  return files;
+}

--- a/lib/core/watch.ts
+++ b/lib/core/watch.ts
@@ -4,6 +4,7 @@ import { alerts } from "./alerts";
 import { removeSCSSTypeDefinitionFile } from "./remove-file";
 import { writeFile } from "./write-file";
 import { ConfigOptions } from "./types";
+import { listFilesAndPerformSanityChecks } from "./list-files-and-perform-sanity-checks";
 
 /**
  * Watch a file glob and generate the corresponding types.
@@ -12,6 +13,10 @@ import { ConfigOptions } from "./types";
  * @param options the CLI options
  */
 export const watch = (pattern: string, options: ConfigOptions): void => {
+  // This is called so that we print a warning instead if no files matched the
+  // pattern
+  listFilesAndPerformSanityChecks(pattern, options);
+
   alerts.success("Watching files...");
 
   chokidar

--- a/lib/core/watch.ts
+++ b/lib/core/watch.ts
@@ -13,8 +13,6 @@ import { listFilesAndPerformSanityChecks } from "./list-files-and-perform-sanity
  * @param options the CLI options
  */
 export const watch = (pattern: string, options: ConfigOptions): void => {
-  // This is called so that we print a warning instead if no files matched the
-  // pattern
   listFilesAndPerformSanityChecks(pattern, options);
 
   alerts.success("Watching files...");


### PR DESCRIPTION
I noticed that a warning is printed if 0 files match the pattern in "non-watch" mode, but the warning is not printed in watch mode, it just says "Watching files...". This could be confusing if you are attempting to use watch mode and have passed the wrong glob.