### PR TITLE
Upgrade to node-sass 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "husky": "^7.0.4",
     "jest": "^27.5.1",
     "lint-staged": "^12.3.4",
-    "node-sass": "7.0.3",
+    "node-sass": "8.0.0",
     "node-sass-json-importer": "^4.3.0",
     "prettier": "^2.5.1",
     "sass": "^1.49.7",
@@ -66,7 +66,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "node-sass": "^7.0.3",
+    "node-sass": "7.x 8.x",
     "sass": "^1.49.7"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Upgrade to node-sass 8.x

Update peer-dependency to 7.x 8.x since the package is not tightly bonded to 7.0.3 and works for 7.x and 8.x node-sass