### PR TITLE
feat(node-sass): support 8.x as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "node-sass": "^7.0.3",
+    "node-sass": "^7.0.3 || ^8.0.0",
     "sass": "^1.49.7"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Update package.json to support node-sass 8.x as peer dependency