### PR TITLE
fix: export the named types as declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ For example, given the following SCSS:
 The following type definitions will be generated:
 
 ```typescript
-export const text: string;
-export const textHighlighted: string;
+export declare const text: string;
+export declare const textHighlighted: string;
 ```
 
 ## Basic Usage
@@ -162,8 +162,8 @@ Given the following SCSS:
 The following type definitions will be generated:
 
 ```typescript
-export const text: string;
-export const textHighlighted: string;
+export declare const text: string;
+export declare const textHighlighted: string;
 ```
 
 #### `default`

--- a/__tests__/__snapshots__/main.test.ts.snap
+++ b/__tests__/__snapshots__/main.test.ts.snap
@@ -3,62 +3,62 @@
 exports[`node-sass implementation main outputs the correct files when outputFolder is passed 1`] = `
 Array [
   Object {
-    "contents": "export const myCustomClass: string;
-export const nestedAnother: string;
-export const nestedClass: string;
-export const nestedStyles: string;
-export const number1: string;
-export const someStyles: string;
+    "contents": "export declare const myCustomClass: string;
+export declare const nestedAnother: string;
+export declare const nestedClass: string;
+export declare const nestedStyles: string;
+export declare const number1: string;
+export declare const someStyles: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/alias-prefixes.scss.d.ts",
   },
   Object {
-    "contents": "export const myCustomClass: string;
-export const nestedAnother: string;
-export const nestedClass: string;
-export const number1: string;
-export const someClass: string;
-export const someStyles: string;
+    "contents": "export declare const myCustomClass: string;
+export declare const nestedAnother: string;
+export declare const nestedClass: string;
+export declare const number1: string;
+export declare const someClass: string;
+export declare const someStyles: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/aliases.scss.d.ts",
   },
   Object {
-    "contents": "export const nestedAnother: string;
-export const nestedClass: string;
-export const number1: string;
-export const someStyles: string;
+    "contents": "export declare const nestedAnother: string;
+export declare const nestedClass: string;
+export declare const number1: string;
+export declare const someStyles: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/complex.scss.d.ts",
   },
   Object {
-    "contents": "export const composedClass: string;
+    "contents": "export declare const composedClass: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/composes.scss.d.ts",
   },
   Object {
-    "contents": "export const app: string;
-export const appHeader: string;
-export const logo: string;
+    "contents": "export declare const app: string;
+export declare const appHeader: string;
+export declare const logo: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/dashes.scss.d.ts",
   },
   Object {
-    "contents": "export const globalStyle: string;
+    "contents": "export declare const globalStyle: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/global-variables.scss.d.ts",
   },
   Object {
-    "contents": "export const randomClass: string;
+    "contents": "export declare const randomClass: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/invalid.scss.d.ts",
   },
   Object {
-    "contents": "export const nestedStyles: string;
+    "contents": "export declare const nestedStyles: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/nested-styles/style.scss.d.ts",
   },
   Object {
-    "contents": "export const someClass: string;
+    "contents": "export declare const someClass: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/style.scss.d.ts",
   },
@@ -205,62 +205,62 @@ export default styles;
 exports[`sass implementation main outputs the correct files when outputFolder is passed 1`] = `
 Array [
   Object {
-    "contents": "export const myCustomClass: string;
-export const nestedAnother: string;
-export const nestedClass: string;
-export const nestedStyles: string;
-export const number1: string;
-export const someStyles: string;
+    "contents": "export declare const myCustomClass: string;
+export declare const nestedAnother: string;
+export declare const nestedClass: string;
+export declare const nestedStyles: string;
+export declare const number1: string;
+export declare const someStyles: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/alias-prefixes.scss.d.ts",
   },
   Object {
-    "contents": "export const myCustomClass: string;
-export const nestedAnother: string;
-export const nestedClass: string;
-export const number1: string;
-export const someClass: string;
-export const someStyles: string;
+    "contents": "export declare const myCustomClass: string;
+export declare const nestedAnother: string;
+export declare const nestedClass: string;
+export declare const number1: string;
+export declare const someClass: string;
+export declare const someStyles: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/aliases.scss.d.ts",
   },
   Object {
-    "contents": "export const nestedAnother: string;
-export const nestedClass: string;
-export const number1: string;
-export const someStyles: string;
+    "contents": "export declare const nestedAnother: string;
+export declare const nestedClass: string;
+export declare const number1: string;
+export declare const someStyles: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/complex.scss.d.ts",
   },
   Object {
-    "contents": "export const composedClass: string;
+    "contents": "export declare const composedClass: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/composes.scss.d.ts",
   },
   Object {
-    "contents": "export const app: string;
-export const appHeader: string;
-export const logo: string;
+    "contents": "export declare const app: string;
+export declare const appHeader: string;
+export declare const logo: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/dashes.scss.d.ts",
   },
   Object {
-    "contents": "export const globalStyle: string;
+    "contents": "export declare const globalStyle: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/global-variables.scss.d.ts",
   },
   Object {
-    "contents": "export const randomClass: string;
+    "contents": "export declare const randomClass: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/invalid.scss.d.ts",
   },
   Object {
-    "contents": "export const nestedStyles: string;
+    "contents": "export declare const nestedStyles: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/nested-styles/style.scss.d.ts",
   },
   Object {
-    "contents": "export const someClass: string;
+    "contents": "export declare const someClass: string;
 ",
     "path": "../__generated__/__tests__/dummy-styles/style.scss.d.ts",
   },

--- a/__tests__/core/write-file.test.ts
+++ b/__tests__/core/write-file.test.ts
@@ -42,7 +42,7 @@ describeAllImplementations((implementation) => {
       );
       expect(fs.writeFileSync).toBeCalledWith(
         expectedPath,
-        "export const someClass: string;\n"
+        "export declare const someClass: string;\n"
       );
       expect(console.log).toBeCalledWith(
         expect.stringContaining(`[GENERATED TYPES] ${expectedPath}`)
@@ -104,7 +104,7 @@ describeAllImplementations((implementation) => {
         );
         expect(fs.writeFileSync).toBeCalledWith(
           expectedPath,
-          "export const someClass: string;\n"
+          "export declare const someClass: string;\n"
         );
         expect(console.log).toBeCalledWith(
           expect.stringContaining(`[GENERATED TYPES] ${expectedPath}`)

--- a/__tests__/dummy-styles/alias-prefixes.scss.d.ts
+++ b/__tests__/dummy-styles/alias-prefixes.scss.d.ts
@@ -1,5 +1,5 @@
-export const someStyles: string;
-export const nestedClass: string;
-export const nestedAnother: string;
-export const nestedStyles: string;
-export const myCustomClass: string;
+export declare const someStyles: string;
+export declare const nestedClass: string;
+export declare const nestedAnother: string;
+export declare const nestedStyles: string;
+export declare const myCustomClass: string;

--- a/__tests__/dummy-styles/aliases.scss.d.ts
+++ b/__tests__/dummy-styles/aliases.scss.d.ts
@@ -1,5 +1,5 @@
-export const someStyles: string;
-export const nestedClass: string;
-export const nestedAnother: string;
-export const someClass: string;
-export const myCustomClass: string;
+export declare const someStyles: string;
+export declare const nestedClass: string;
+export declare const nestedAnother: string;
+export declare const someClass: string;
+export declare const myCustomClass: string;

--- a/__tests__/dummy-styles/complex.scss.d.ts
+++ b/__tests__/dummy-styles/complex.scss.d.ts
@@ -1,3 +1,3 @@
-export const someStyles: string;
-export const nestedClass: string;
-export const nestedAnother: string;
+export declare const someStyles: string;
+export declare const nestedClass: string;
+export declare const nestedAnother: string;

--- a/__tests__/dummy-styles/composes.scss.d.ts
+++ b/__tests__/dummy-styles/composes.scss.d.ts
@@ -1,1 +1,1 @@
-export const composedClass: string;
+export declare const composedClass: string;

--- a/__tests__/dummy-styles/dashes.scss.d.ts
+++ b/__tests__/dummy-styles/dashes.scss.d.ts
@@ -1,3 +1,3 @@
-export const app: string;
-export const logo: string;
-export const appHeader: string;
+export declare const app: string;
+export declare const logo: string;
+export declare const appHeader: string;

--- a/__tests__/dummy-styles/invalid.scss.d.ts
+++ b/__tests__/dummy-styles/invalid.scss.d.ts
@@ -1,1 +1,1 @@
-export const nope: string;
+export declare const nope: string;

--- a/__tests__/dummy-styles/nested-styles/style.scss.d.ts
+++ b/__tests__/dummy-styles/nested-styles/style.scss.d.ts
@@ -1,1 +1,1 @@
-export const nestedStyles: string;
+export declare const nestedStyles: string;

--- a/__tests__/dummy-styles/style.scss.d.ts
+++ b/__tests__/dummy-styles/style.scss.d.ts
@@ -1,1 +1,1 @@
-export const someClass: string;
+export declare const someClass: string;

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -60,11 +60,11 @@ describeAllImplementations((implementation) => {
 
       expect(fs.writeFileSync).toBeCalledWith(
         `${expectedDirname}/complex.scss.d.ts`,
-        "export const nestedAnother: string;\nexport const nestedClass: string;\nexport const number1: string;\nexport const someStyles: string;\n"
+        "export declare const nestedAnother: string;\nexport declare const nestedClass: string;\nexport declare const number1: string;\nexport declare const someStyles: string;\n"
       );
       expect(fs.writeFileSync).toBeCalledWith(
         `${expectedDirname}/style.scss.d.ts`,
-        "export const someClass: string;\n"
+        "export declare const someClass: string;\n"
       );
     });
 
@@ -101,7 +101,7 @@ describeAllImplementations((implementation) => {
 
       expect(fs.writeFileSync).toBeCalledWith(
         `${expectedDirname}/complex.scss.d.ts`,
-        "export const nestedAnother: string;\nexport const nestedClass: string;\nexport const number1: string;\nexport const someStyles: string;\n"
+        "export declare const nestedAnother: string;\nexport declare const nestedClass: string;\nexport declare const number1: string;\nexport declare const someStyles: string;\n"
       );
 
       // Files that should match the ignore pattern.

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -19,7 +19,7 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
       });
 
       expect(definition).toEqual(
-        "export const myClass: string;\nexport const yourClass: string;\n"
+        "export declare const myClass: string;\nexport declare const yourClass: string;\n"
       );
     });
 
@@ -40,7 +40,7 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
         exportType: "named",
       });
 
-      expect(definition).toEqual("export const myClass: string;\n");
+      expect(definition).toEqual("export declare const myClass: string;\n");
       expect(console.log).toBeCalledWith(
         expect.stringContaining(`[SKIPPING] 'if' is a reserved keyword`)
       );
@@ -53,7 +53,7 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
         exportType: "named",
       });
 
-      expect(definition).toEqual("export const myClass: string;\n");
+      expect(definition).toEqual("export declare const myClass: string;\n");
       expect(console.log).toBeCalledWith(
         expect.stringContaining(`[SKIPPING] 'invalid-variable' contains dashes`)
       );
@@ -119,7 +119,7 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
       });
 
       expect(definition).toEqual(
-        "export const myClass: string;\nexport const yourClass: string;\n"
+        "export declare const myClass: string;\nexport declare const yourClass: string;\n"
       );
     });
   });

--- a/examples/basic/feature-a/style.scss.d.ts
+++ b/examples/basic/feature-a/style.scss.d.ts
@@ -1,3 +1,3 @@
 // example banner
-export const text: string;
-export const textHighlighted: string;
+export declare const text: string;
+export declare const textHighlighted: string;

--- a/examples/basic/feature-b/style.scss.d.ts
+++ b/examples/basic/feature-b/style.scss.d.ts
@@ -1,2 +1,2 @@
 // example banner
-export const topBanner: string;
+export declare const topBanner: string;

--- a/examples/output-folder/__generated__/examples/output-folder/feature-a/a.scss.d.ts
+++ b/examples/output-folder/__generated__/examples/output-folder/feature-a/a.scss.d.ts
@@ -1,1 +1,1 @@
-export const a: string;
+export declare const a: string;

--- a/examples/output-folder/__generated__/examples/output-folder/feature-b/b.scss.d.ts
+++ b/examples/output-folder/__generated__/examples/output-folder/feature-b/b.scss.d.ts
@@ -1,1 +1,1 @@
-export const b: string;
+export declare const b: string;

--- a/examples/output-folder/__generated__/examples/output-folder/feature-c/c.scss.d.ts
+++ b/examples/output-folder/__generated__/examples/output-folder/feature-c/c.scss.d.ts
@@ -1,1 +1,1 @@
-export const c: string;
+export declare const c: string;

--- a/examples/output-folder/__generated__/examples/output-folder/feature-c/nested/nested.scss.d.ts
+++ b/examples/output-folder/__generated__/examples/output-folder/feature-c/nested/nested.scss.d.ts
@@ -1,1 +1,1 @@
-export const nested: string;
+export declare const nested: string;

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -28,7 +28,7 @@ export const quoteTypeDefault: QuoteType = "single";
 export const bannerTypeDefault: string = "";
 
 const classNameToNamedTypeDefinition = (className: ClassName) =>
-  `export const ${className}: string;`;
+  `export declare const ${className}: string;`;
 
 const classNameToType = (className: ClassName, quoteType: QuoteType) => {
   const quote = quoteType === "single" ? "'" : '"';


### PR DESCRIPTION
This will prevent some errors in Esbuild, where it expects the constants to be initialised even though they are in the .d.ts files.

This error is fixed after this PR:

```js
Error: Transform failed with 1 error:
<stdin>:1:13: ERROR: The constant "confirmationInput" must be initialized
    at failureErrorWithLog (/home/aminya/test/node_modules/esbuild/lib/main.js:1624:15)
    at /home/aminya/test/node_modules/esbuild/lib/main.js:1413:29
    at /home/aminya/test/node_modules/esbuild/lib/main.js:678:9
    at handleIncomingPacket (/home/aminya/test/node_modules/esbuild/lib/main.js:775:9)
    at Socket.readFromStdout (/home/aminya/test/node_modules/esbuild/lib/main.js:644:7)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:324:12)
    at readableAddChunk (node:internal/streams/readable:297:9)
    at Readable.push (node:internal/streams/readable:234:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) {
  errors: [
    {
      detail: undefined,
      id: '',
      location: [Object],
      notes: [],
      pluginName: '',
      text: 'The constant "confirmationInput" must be initialized'
    }
  ],
  warnings: []
}
```