### PR TITLE
feat(config): support `modules` config to customize css modules processing

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1,10 +1,12 @@
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 
 describe("cli", () => {
   it("should run when no files are found", () => {
-    const result = execSync("npm run typed-scss-modules src").toString();
+    const result = spawnSync("npm run typed-scss-modules src", {
+      shell: true,
+    });
 
-    expect(result).toContain("No files found.");
+    expect(result.stderr.toString()).toContain("No files found.");
   });
 
   describe("examples", () => {

--- a/__tests__/core/alerts.test.ts
+++ b/__tests__/core/alerts.test.ts
@@ -2,13 +2,16 @@ import { alerts, setAlertsLogLevel } from "../../lib/core";
 
 describe("alerts", () => {
   let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     logSpy = jest.spyOn(console, "log").mockImplementation();
+    warnSpy = jest.spyOn(console, "warn").mockImplementation();
   });
 
   afterEach(() => {
     logSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   const TEST_ALERT_MSG = "TEST ALERT MESSAGE";
@@ -20,29 +23,29 @@ describe("alerts", () => {
 
     alerts.error(TEST_ALERT_MSG);
 
-    expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
+    expect(console.warn).toHaveBeenLastCalledWith(EXPECTED);
     //make sure each alert only calls console.log once
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
 
     alerts.warn(TEST_ALERT_MSG);
 
-    expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenLastCalledWith(EXPECTED);
+    expect(console.warn).toHaveBeenCalledTimes(2);
 
     alerts.notice(TEST_ALERT_MSG);
 
     expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(3);
+    expect(console.log).toHaveBeenCalledTimes(1);
 
     alerts.info(TEST_ALERT_MSG);
 
     expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(4);
+    expect(console.log).toHaveBeenCalledTimes(2);
 
     alerts.success(TEST_ALERT_MSG);
 
     expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(5);
+    expect(console.log).toHaveBeenCalledTimes(3);
   });
 
   it("should only print error messages with error log level", () => {
@@ -50,8 +53,8 @@ describe("alerts", () => {
 
     alerts.error(TEST_ALERT_MSG);
 
-    expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenLastCalledWith(EXPECTED);
+    expect(console.warn).toHaveBeenCalledTimes(1);
 
     alerts.warn(TEST_ALERT_MSG);
     alerts.notice(TEST_ALERT_MSG);
@@ -59,7 +62,7 @@ describe("alerts", () => {
     alerts.success(TEST_ALERT_MSG);
 
     //shouldn't change
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
   it("should print all but warning messages with info log level", () => {
@@ -67,27 +70,27 @@ describe("alerts", () => {
 
     alerts.error(TEST_ALERT_MSG);
 
-    expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenLastCalledWith(EXPECTED);
+    expect(console.warn).toHaveBeenCalledTimes(1);
 
     alerts.notice(TEST_ALERT_MSG);
 
     expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(2);
+    expect(console.log).toHaveBeenCalledTimes(1);
 
     alerts.info(TEST_ALERT_MSG);
 
     expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(3);
+    expect(console.log).toHaveBeenCalledTimes(2);
 
     alerts.success(TEST_ALERT_MSG);
 
     expect(console.log).toHaveBeenLastCalledWith(EXPECTED);
-    expect(console.log).toHaveBeenCalledTimes(4);
+    expect(console.log).toHaveBeenCalledTimes(3);
 
     alerts.warn(TEST_ALERT_MSG);
 
-    expect(console.log).toHaveBeenCalledTimes(4);
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
   it("should print no messages with silent log level", () => {
@@ -100,5 +103,6 @@ describe("alerts", () => {
     alerts.success(TEST_ALERT_MSG);
 
     expect(console.log).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/core/generate.test.ts
+++ b/__tests__/core/generate.test.ts
@@ -27,9 +27,16 @@ describeAllImplementations((implementation) => {
         updateStaleOnly: false,
         logLevel: "verbose",
         outputFolder: null,
+        aliases: {
+          "~fancy-import": "complex",
+          "~another": "style",
+        },
+        aliasPrefixes: {
+          "~": "nested-styles/",
+        },
       });
 
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(6);
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(9);
     });
   });
 });

--- a/__tests__/core/list-different.test.ts
+++ b/__tests__/core/list-different.test.ts
@@ -7,6 +7,7 @@ describeAllImplementations((implementation) => {
 
     beforeEach(() => {
       console.log = jest.fn();
+      console.warn = jest.fn();
       exit = jest.spyOn(process, "exit").mockImplementation();
     });
 
@@ -41,10 +42,10 @@ describeAllImplementations((implementation) => {
       });
 
       expect(exit).toHaveBeenCalledWith(1);
-      expect(console.log).toHaveBeenCalledWith(
+      expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(`[INVALID TYPES] Check type definitions for`)
       );
-      expect(console.log).toHaveBeenCalledWith(
+      expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(`invalid.scss`)
       );
     });
@@ -69,8 +70,8 @@ describeAllImplementations((implementation) => {
         outputFolder: null,
       });
 
-      expect(console.log).toHaveBeenCalledTimes(1);
-      expect(console.log).toHaveBeenCalledWith(
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(`Only 1 file found for`)
       );
       expect(exit).not.toHaveBeenCalled();
@@ -96,6 +97,7 @@ describeAllImplementations((implementation) => {
       });
 
       expect(exit).not.toHaveBeenCalled();
+      expect(console.warn).not.toHaveBeenCalled();
       expect(console.log).not.toHaveBeenCalled();
     });
 
@@ -119,12 +121,12 @@ describeAllImplementations((implementation) => {
       });
 
       expect(exit).toHaveBeenCalledWith(1);
-      expect(console.log).toHaveBeenCalledWith(
+      expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           `[INVALID TYPES] Type file needs to be generated for`
         )
       );
-      expect(console.log).toHaveBeenCalledWith(
+      expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(`no-generated.scss`)
       );
     });
@@ -149,8 +151,8 @@ describeAllImplementations((implementation) => {
       });
 
       expect(exit).not.toHaveBeenCalled();
-      expect(console.log).toHaveBeenCalledTimes(1);
-      expect(console.log).toHaveBeenCalledWith(
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(`No files found`)
       );
     });

--- a/__tests__/core/list-files-and-perform-sanity-check.test.ts
+++ b/__tests__/core/list-files-and-perform-sanity-check.test.ts
@@ -19,7 +19,7 @@ const options: ConfigOptions = {
 
 describe("listAllFilesAndPerformSanityCheck", () => {
   beforeEach(() => {
-    console.log = jest.fn();
+    console.warn = jest.fn();
   });
 
   it("prints a warning if the pattern matches 0 files", () => {
@@ -27,7 +27,7 @@ describe("listAllFilesAndPerformSanityCheck", () => {
 
     listFilesAndPerformSanityChecks(pattern, options);
 
-    expect(console.log).toHaveBeenCalledWith(
+    expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("No files found.")
     );
   });
@@ -37,7 +37,7 @@ describe("listAllFilesAndPerformSanityCheck", () => {
 
     listFilesAndPerformSanityChecks(pattern, options);
 
-    expect(console.log).toHaveBeenCalledWith(
+    expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("Only 1 file found for")
     );
   });

--- a/__tests__/dummy-styles/global-variables.scss
+++ b/__tests__/dummy-styles/global-variables.scss
@@ -1,3 +1,5 @@
+$global-red: #ff0000;
+
 .globalStyle {
   background-color: $global-red;
 }

--- a/__tests__/typescript/class-names-to-type-definitions.test.ts
+++ b/__tests__/typescript/class-names-to-type-definitions.test.ts
@@ -7,7 +7,7 @@ jest.mock("../../lib/prettier/can-resolve", () => ({
 
 describe("classNamesToTypeDefinitions (without Prettier)", () => {
   beforeEach(() => {
-    console.log = jest.fn();
+    console.warn = jest.fn();
   });
 
   describe("named", () => {
@@ -41,7 +41,7 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
       });
 
       expect(definition).toEqual("export declare const myClass: string;\n");
-      expect(console.log).toHaveBeenCalledWith(
+      expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(`[SKIPPING] 'if' is a reserved keyword`)
       );
     });
@@ -54,7 +54,7 @@ describe("classNamesToTypeDefinitions (without Prettier)", () => {
       });
 
       expect(definition).toEqual("export declare const myClass: string;\n");
-      expect(console.log).toHaveBeenCalledWith(
+      expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(`[SKIPPING] 'invalid-variable' contains dashes`)
       );
     });

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import yargs from "yargs";
+import { alerts } from "./core";
 import { IMPLEMENTATIONS } from "./implementations";
 import { main } from "./main";
 import { Aliases, NAME_FORMATS } from "./sass";
@@ -145,4 +146,8 @@ const { _: patterns, ...rest } = yargs
   .parseSync();
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-main(patterns[0] as string, { ...rest });
+main(patterns[0] as string, { ...rest }).catch((error) => {
+  alerts.error("Encountered an error while generating type definitions.");
+  alerts.error(error);
+  process.exitCode = 1;
+});

--- a/lib/core/alerts.ts
+++ b/lib/core/alerts.ts
@@ -38,17 +38,21 @@ const normalizeErrorMessage = (error: string | Error) => {
     const { message, file, line, column } = error as SassError;
     const location = file ? ` (${file}[${line}:${column}])` : "";
 
-    const wrappedError = new Error(`SASS Error ${location}\n${message}`);
-    wrappedError.stack = error.stack;
+    const wrappedError = new Error(`SASS Error ${location}\n${message}`, {
+      cause: error,
+    });
+
+    wrappedError.stack = chalk.red(wrappedError.stack);
+
     return wrappedError;
   }
 
-  return error;
+  return chalk.red(error);
 };
 const error = withLogLevelsRestriction(
   ["verbose", "error", "info"],
   (message: string | Error) => {
-    console.warn(chalk.red(normalizeErrorMessage(message)));
+    console.warn(normalizeErrorMessage(message));
   }
 );
 const warn = withLogLevelsRestriction(["verbose"], (message: string) =>

--- a/lib/core/alerts.ts
+++ b/lib/core/alerts.ts
@@ -34,10 +34,10 @@ const withLogLevelsRestriction =
 
 const error = withLogLevelsRestriction(
   ["verbose", "error", "info"],
-  (message: string) => console.log(chalk.red(message))
+  (message: string) => console.warn(chalk.red(message))
 );
 const warn = withLogLevelsRestriction(["verbose"], (message: string) =>
-  console.log(chalk.yellowBright(message))
+  console.warn(chalk.yellowBright(message))
 );
 const notice = withLogLevelsRestriction(
   ["verbose", "info"],

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -1,3 +1,4 @@
+import type PostCSSModulesPlugin from "postcss-modules";
 import { SASSOptions } from "../sass";
 import { ExportType, LogLevel, QuoteType } from "../typescript";
 
@@ -18,4 +19,7 @@ export interface CLIOptions extends Exclude<SASSOptions, CLIOnlyOptions> {
   outputFolder: string | null;
 }
 
-export interface ConfigOptions extends CLIOptions, SASSOptions {}
+type PostCSSModulesOptions = Parameters<PostCSSModulesPlugin>[0];
+export interface ConfigOptions extends CLIOptions, SASSOptions {
+  modules?: PostCSSModulesOptions;
+}

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -2,9 +2,9 @@ import type PostCSSModulesPlugin from "postcss-modules";
 import { SASSOptions } from "../sass";
 import { ExportType, LogLevel, QuoteType } from "../typescript";
 
-type CLIOnlyOptions = Extract<keyof SASSOptions, "importer">;
+type NonCLIOptions = "importer";
 
-export interface CLIOptions extends Exclude<SASSOptions, CLIOnlyOptions> {
+export interface CLIOptions extends Exclude<SASSOptions, NonCLIOptions> {
   banner: string;
   ignore: string[];
   ignoreInitial: boolean;

--- a/lib/core/write-file.ts
+++ b/lib/core/write-file.ts
@@ -7,7 +7,7 @@ import {
 } from "../typescript";
 import { alerts } from "./alerts";
 import { removeSCSSTypeDefinitionFile } from "./remove-file";
-import { CLIOptions } from "./types";
+import { ConfigOptions } from "./types";
 
 /**
  * Given a single file generate the proper types.
@@ -17,7 +17,7 @@ import { CLIOptions } from "./types";
  */
 export const writeFile = async (
   file: string,
-  options: CLIOptions
+  options: ConfigOptions
 ): Promise<void> => {
   const classNames = await fileToClassNames(file, options);
   const typeDefinition = await classNamesToTypeDefinitions({

--- a/lib/core/write-file.ts
+++ b/lib/core/write-file.ts
@@ -22,7 +22,11 @@ export const writeFile = async (
   const classNames = await fileToClassNames(file, options);
   const typeDefinition = await classNamesToTypeDefinitions({
     classNames,
-    ...options,
+    banner: options.banner,
+    exportType: options.exportType,
+    exportTypeInterface: options.exportTypeInterface,
+    exportTypeName: options.exportTypeName,
+    quoteType: options.quoteType,
   });
 
   const typesPath = getTypeDefinitionPath(file, options);

--- a/lib/core/write-file.ts
+++ b/lib/core/write-file.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import { SassError } from "node-sass";
 import path from "path";
 import { fileToClassNames } from "../sass";
 import {
@@ -20,57 +19,51 @@ export const writeFile = async (
   file: string,
   options: CLIOptions
 ): Promise<void> => {
-  try {
-    const classNames = await fileToClassNames(file, options);
-    const typeDefinition = await classNamesToTypeDefinitions({
-      classNames,
-      ...options,
-    });
+  const classNames = await fileToClassNames(file, options);
+  const typeDefinition = await classNamesToTypeDefinitions({
+    classNames,
+    ...options,
+  });
 
-    const typesPath = getTypeDefinitionPath(file, options);
-    const typesExist = fs.existsSync(typesPath);
+  const typesPath = getTypeDefinitionPath(file, options);
+  const typesExist = fs.existsSync(typesPath);
 
-    // Avoid outputting empty type definition files.
-    // If the file exists and the type definition is now empty, remove the file.
-    if (!typeDefinition) {
-      if (typesExist) {
-        removeSCSSTypeDefinitionFile(file, options);
-      } else {
-        alerts.notice(`[NO GENERATED TYPES] ${file}`);
-      }
+  // Avoid outputting empty type definition files.
+  // If the file exists and the type definition is now empty, remove the file.
+  if (!typeDefinition) {
+    if (typesExist) {
+      removeSCSSTypeDefinitionFile(file, options);
+    } else {
+      alerts.notice(`[NO GENERATED TYPES] ${file}`);
+    }
+    return;
+  }
+
+  // Avoid re-writing the file if it hasn't changed.
+  // First by checking the file modification time, then
+  // by comparing the file contents.
+  if (options.updateStaleOnly && typesExist) {
+    const fileModified = fs.statSync(file).mtime;
+    const typeDefinitionModified = fs.statSync(typesPath).mtime;
+
+    if (fileModified < typeDefinitionModified) {
       return;
     }
 
-    // Avoid re-writing the file if it hasn't changed.
-    // First by checking the file modification time, then
-    // by comparing the file contents.
-    if (options.updateStaleOnly && typesExist) {
-      const fileModified = fs.statSync(file).mtime;
-      const typeDefinitionModified = fs.statSync(typesPath).mtime;
-
-      if (fileModified < typeDefinitionModified) {
-        return;
-      }
-
-      const existingTypeDefinition = fs.readFileSync(typesPath, "utf8");
-      if (existingTypeDefinition === typeDefinition) {
-        return;
-      }
+    const existingTypeDefinition = fs.readFileSync(typesPath, "utf8");
+    if (existingTypeDefinition === typeDefinition) {
+      return;
     }
-
-    // Files can be written to arbitrary directories and need to
-    // be nested to match the project structure so it's possible
-    // there are multiple directories that need to be created.
-    const dirname = path.dirname(typesPath);
-    if (!fs.existsSync(dirname)) {
-      fs.mkdirSync(dirname, { recursive: true });
-    }
-
-    fs.writeFileSync(typesPath, typeDefinition);
-    alerts.success(`[GENERATED TYPES] ${typesPath}`);
-  } catch (error) {
-    const { message, file, line, column } = error as SassError;
-    const location = file ? ` (${file}[${line}:${column}])` : "";
-    alerts.error(`${message}${location}`);
   }
+
+  // Files can be written to arbitrary directories and need to
+  // be nested to match the project structure so it's possible
+  // there are multiple directories that need to be created.
+  const dirname = path.dirname(typesPath);
+  if (!fs.existsSync(dirname)) {
+    fs.mkdirSync(dirname, { recursive: true });
+  }
+
+  fs.writeFileSync(typesPath, typeDefinition);
+  alerts.success(`[GENERATED TYPES] ${typesPath}`);
 };

--- a/lib/load.ts
+++ b/lib/load.ts
@@ -1,7 +1,7 @@
 import { bundleRequire } from "bundle-require";
 import JoyCon from "joycon";
 import path from "path";
-import { alerts, CLIOptions, ConfigOptions } from "./core";
+import { CLIOptions, ConfigOptions } from "./core";
 import { getDefaultImplementation } from "./implementations";
 import { nameFormatDefault } from "./sass";
 import {
@@ -39,25 +39,16 @@ export const loadConfig = async (): Promise<
   );
 
   if (configPath) {
-    try {
-      const configModule = await bundleRequire({
-        filepath: configPath,
-      });
+    const configModule = await bundleRequire({
+      filepath: configPath,
+    });
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const config: ConfigOptions =
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        configModule.mod.config || configModule.mod.default || configModule.mod;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const config: ConfigOptions =
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      configModule.mod.config || configModule.mod.default || configModule.mod;
 
-      return config;
-    } catch (error) {
-      alerts.error(
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        `An error occurred loading the config file "${configPath}":\n${error}`
-      );
-
-      return {};
-    }
+    return config;
   }
 
   return {};

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -5,6 +5,7 @@ import {
   snakeCase,
 } from "change-case";
 import fs from "fs";
+import { ConfigOptions } from "../core/types";
 import { Implementations, getImplementation } from "../implementations";
 import { Aliases, SASSImporterOptions, customImporters } from "./importer";
 import { sourceToClassNames } from "./source-to-class-names";
@@ -44,7 +45,9 @@ export const nameFormatDefault: NameFormatWithTransformer = "camel";
 
 export const fileToClassNames = async (
   file: string,
-  {
+  options: ConfigOptions = {} as ConfigOptions
+) => {
+  const {
     additionalData,
     includePaths = [],
     nameFormat: rawNameFormat,
@@ -52,8 +55,8 @@ export const fileToClassNames = async (
     aliases,
     aliasPrefixes,
     importer,
-  }: SASSOptions = {} as SASSOptions
-) => {
+  } = options;
+
   const { renderSync } = getImplementation(implementation);
 
   const nameFormat = (
@@ -74,7 +77,7 @@ export const fileToClassNames = async (
     importer: customImporters({ aliases, aliasPrefixes, importer }),
   });
 
-  const classNames = await sourceToClassNames(result.css, file);
+  const classNames = await sourceToClassNames(result.css, file, options);
   const transformers = nameFormats.map((item) => transformersMap[item]);
   const transformedClassNames = new Set<ClassName>([]);
   classNames.forEach((className: ClassName) => {

--- a/lib/sass/file-to-class-names.ts
+++ b/lib/sass/file-to-class-names.ts
@@ -39,13 +39,18 @@ export interface SASSOptions extends SASSImporterOptions {
   additionalData?: string;
   includePaths?: string[];
   nameFormat?: string | string[];
-  implementation: Implementations;
+  implementation?: Implementations;
 }
 export const nameFormatDefault: NameFormatWithTransformer = "camel";
 
+export type FileToClassNameOptions = Pick<
+  ConfigOptions,
+  keyof SASSOptions | "nameFormat" | "modules"
+>;
+
 export const fileToClassNames = async (
   file: string,
-  options: ConfigOptions = {} as ConfigOptions
+  options: FileToClassNameOptions = {} as FileToClassNameOptions
 ) => {
   const {
     additionalData,

--- a/lib/sass/source-to-class-names.ts
+++ b/lib/sass/source-to-class-names.ts
@@ -1,16 +1,19 @@
 import postcss from "postcss";
 import PostcssModulesPlugin from "postcss-modules";
+import { ConfigOptions } from "../core/types";
 
 /**
  * Converts a CSS source string to a list of exports (class names, keyframes, etc.)
  */
 export const sourceToClassNames = async (
   source: { toString(): string },
-  file: string
+  file: string,
+  { modules = {} }: ConfigOptions = {} as ConfigOptions
 ) => {
   let result: Record<string, string> = {};
   await postcss([
     PostcssModulesPlugin({
+      ...modules,
       getJSON: (_, json) => {
         result = json;
       },

--- a/lib/sass/source-to-class-names.ts
+++ b/lib/sass/source-to-class-names.ts
@@ -1,8 +1,28 @@
+import * as proxy from "identity-obj-proxy";
 import postcss from "postcss";
 import PostcssModulesPlugin from "postcss-modules";
 import { ConfigOptions } from "../core/types";
 
 export type SourceToClassNamesOptions = Pick<ConfigOptions, "modules">;
+
+/**
+ * Use identity-obj-proxy for any imported CSS modules
+ *
+ * This should not affect the final for a given file, since the types are
+ * generated only using the classes defined in the current file.
+ *
+ * This has the added benefit of reducing system calls and disk access,
+ * so may perform faster in large projects.
+ *
+ * The only drawback is that this does not process the import tree
+ * the way in which it is intended to be used, so broken imports
+ * will not be surfaced by this tool.
+ */
+class IdentityObjProxyLoader {
+  async fetch() {
+    return proxy;
+  }
+}
 
 /**
  * Converts a CSS source string to a list of exports (class names, keyframes, etc.)
@@ -16,6 +36,7 @@ export const sourceToClassNames = async (
   await postcss([
     PostcssModulesPlugin({
       ...modules,
+      Loader: IdentityObjProxyLoader,
       getJSON: (_, json) => {
         result = json;
       },

--- a/lib/sass/source-to-class-names.ts
+++ b/lib/sass/source-to-class-names.ts
@@ -2,13 +2,15 @@ import postcss from "postcss";
 import PostcssModulesPlugin from "postcss-modules";
 import { ConfigOptions } from "../core/types";
 
+export type SourceToClassNamesOptions = Pick<ConfigOptions, "modules">;
+
 /**
  * Converts a CSS source string to a list of exports (class names, keyframes, etc.)
  */
 export const sourceToClassNames = async (
   source: { toString(): string },
   file: string,
-  { modules = {} }: ConfigOptions = {} as ConfigOptions
+  { modules = {} }: SourceToClassNamesOptions = {} as SourceToClassNamesOptions
 ) => {
   let result: Record<string, string> = {};
   await postcss([

--- a/lib/sass/source-to-class-names.ts
+++ b/lib/sass/source-to-class-names.ts
@@ -8,8 +8,8 @@ export type SourceToClassNamesOptions = Pick<ConfigOptions, "modules">;
 /**
  * Use identity-obj-proxy for any imported CSS modules
  *
- * This should not affect the final for a given file, since the types are
- * generated only using the classes defined in the current file.
+ * This should not affect the final types for a given file, since the types are
+ * generated only using the classes defined in the current file and not its imports.
  *
  * This has the added benefit of reducing system calls and disk access,
  * so may perform faster in large projects.

--- a/lib/typescript/class-names-to-type-definition.ts
+++ b/lib/typescript/class-names-to-type-definition.ts
@@ -11,9 +11,9 @@ export type QuoteType = "single" | "double";
 export const QUOTE_TYPES: QuoteType[] = ["single", "double"];
 
 export interface TypeDefinitionOptions {
-  banner: string;
+  banner?: string;
   classNames: ClassName[];
-  exportType: ExportType;
+  exportType?: ExportType;
   exportTypeName?: string;
   exportTypeInterface?: string;
   quoteType?: QuoteType;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "chokidar": "^3.5.3",
         "esbuild": "^0.14.21",
         "glob": "^7.2.0",
+        "identity-obj-proxy": "^3.0.0",
         "joycon": "^3.1.1",
         "postcss": "^8.4.27",
         "postcss-modules": "^6.0.0",
@@ -33,6 +34,7 @@
         "@commitlint/config-conventional": "^16.2.1",
         "@commitlint/prompt-cli": "^16.2.1",
         "@types/glob": "^7.2.0",
+        "@types/identity-obj-proxy": "^3.0.2",
         "@types/jest": "^29.5.3",
         "@types/node": "^17.0.18",
         "@types/node-sass": "^4.11.3",
@@ -3174,6 +3176,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/identity-obj-proxy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/identity-obj-proxy/-/identity-obj-proxy-3.0.2.tgz",
+      "integrity": "sha512-0WfmImclMEjbt2oOC4BvvoypsR9Bgsp6OeqEjzSpNBYa1FEHbMGwxADaW/y5liIcnUyMotWtntl3WGWUbSebEw==",
+      "dev": true
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true,
@@ -6113,6 +6121,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "dev": true,
@@ -6260,6 +6273,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ignore": {
@@ -8237,9 +8261,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -12160,9 +12184,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12178,7 +12202,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -16547,6 +16571,12 @@
         "@types/node": "*"
       }
     },
+    "@types/identity-obj-proxy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/identity-obj-proxy/-/identity-obj-proxy-3.0.2.tgz",
+      "integrity": "sha512-0WfmImclMEjbt2oOC4BvvoypsR9Bgsp6OeqEjzSpNBYa1FEHbMGwxADaW/y5liIcnUyMotWtntl3WGWUbSebEw==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true
@@ -18494,6 +18524,11 @@
       "version": "2.1.0",
       "dev": true
     },
+    "harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g=="
+    },
     "has": {
       "version": "1.0.3",
       "dev": true,
@@ -18588,6 +18623,14 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "requires": {}
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "requires": {
+        "harmony-reflect": "^1.4.6"
+      }
     },
     "ignore": {
       "version": "5.2.4",
@@ -19967,9 +20010,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -22736,11 +22779,11 @@
       }
     },
     "postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/reserved-words": "^0.1.0",
     "@types/sass": "^1.16.0",
     "@types/yargs": "^17.0.8",
+    "@types/identity-obj-proxy": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^6.3.0",
     "@typescript-eslint/parser": "^6.3.0",
     "babel-jest": "^29.6.2",
@@ -87,6 +88,7 @@
     }
   },
   "dependencies": {
+    "identity-obj-proxy": "^3.0.0",
     "bundle-require": "^3.0.4",
     "chalk": "4.1.2",
     "change-case": "^4.1.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2022",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
> NOTE: I need this code for one of my projects, so it includes changes from my other PR: #217. This is for convenience so that I can easily install a fork of this repo and get all of the fixes I need. The relevant list of changes can be observed [here](https://github.com/GeorgeTaveras1231/typed-scss-modules/compare/e2b00971d00439dad230114ddbcb836a97f5513e...feat/support-custom-postcss-modules)
> 
> With that said, it may make sense to review that PR first, and block this one until that one is merged. I will follow up and clean up this branch to only include the relevant changes once that is done.


# Goal
1. My goal with this PR is to customize the `resolve` function for CSS modules. I thought it was reasonable to allow customizing `postcss-modules` entirely. See the full list of options [here](https://www.npmjs.com/package/postcss-modules). Some options may not make sense in this context (such as the `scopedNameFormat`) but others like `exportGlobals` and `scopeBehaviour` may be useful for consumers. 
> At the moment, this library has its own logic for manipulating the naming convention, this can be delegated to `postcss-modules` `#localsConvention` option.

Update: I no longer need the ability to customize the `resolve` option. The new `IdentityObjProxyLoader` removes the need to customize the resolution logic as all CSS Module imports are resolved and stubbed. It may still be useful to allow customizing the `postcss-modules` options, but I'd be okay with rolling back that change.