### PR TITLE
feat: exit 1 if some process failed

### DIFF
--- a/lib/core/generate.ts
+++ b/lib/core/generate.ts
@@ -1,3 +1,4 @@
+import { exit } from "process";
 import { alerts } from "./alerts";
 import { listFilesAndPerformSanityChecks } from "./list-files-and-perform-sanity-checks";
 import { ConfigOptions } from "./types";
@@ -26,5 +27,10 @@ export const generate = async (
   );
 
   // Wait for all the type definitions to be written.
-  await Promise.all(files.map((file) => writeFile(file, options)));
+  const result = await Promise.allSettled(
+    files.map((file) => writeFile(file, options))
+  );
+  if (result.some(({ status }) => status === "rejected")) {
+    exit(1);
+  }
 };

--- a/lib/core/write-file.ts
+++ b/lib/core/write-file.ts
@@ -73,5 +73,6 @@ export const writeFile = async (
     const { message, file, line, column } = error as SassError;
     const location = file ? ` (${file}[${line}:${column}])` : "";
     alerts.error(`${message}${location}`);
+    throw error;
   }
 };


### PR DESCRIPTION
close https://github.com/skovy/typed-scss-modules/issues/224

As I wrote in https://github.com/skovy/typed-scss-modules/issues/224, the whole process doesn't fail even if some of building processes fail.

This change will resolve the issue. However, merging it requires updating the tests, which is a significant effort.
If you believe the change is worthwhile, I'm willing to put in the work to update the tests.