### PR TITLE
chore: remove esbuild as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "chalk": "4.1.2",
         "change-case": "^4.1.2",
         "chokidar": "^3.5.3",
-        "esbuild": "^0.14.21",
         "glob": "^7.2.0",
         "joycon": "^3.1.1",
         "postcss": "^8.4.27",
@@ -4993,6 +4992,7 @@
       "version": "0.14.38",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5032,6 +5032,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -17763,6 +17764,7 @@
     },
     "esbuild": {
       "version": "0.14.38",
+      "peer": true,
       "requires": {
         "esbuild-android-64": "0.14.38",
         "esbuild-android-arm64": "0.14.38",
@@ -17788,7 +17790,8 @@
     },
     "esbuild-linux-64": {
       "version": "0.14.38",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "escalade": {
       "version": "3.1.1"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "chalk": "4.1.2",
     "change-case": "^4.1.2",
     "chokidar": "^3.5.3",
-    "esbuild": "^0.14.21",
     "glob": "^7.2.0",
     "joycon": "^3.1.1",
     "postcss": "^8.4.27",


### PR DESCRIPTION
When installing `typed-css-modules` I realized that it is also installing esbuild. My first response is to move it to a devDependency, but it turns out that the package is not being used at all.

Uninstalling `esbuild` still allows the plugin to be built without any issue with `npm run build`.